### PR TITLE
Fix the container boot infinite loop with a fresh install

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -20,13 +20,13 @@ docker exec -ti local-wordpress /bin/bash -c "usermod -u $(id -u) www-data"
 docker exec -ti local-wordpress /bin/bash -c "groupmod -g $(id -g) www-data"
 docker restart local-wordpress
 
-echo "Waiting for containters to boot..."
+echo "Waiting for containers to boot..."
 while [ "$BOOTED" != "true"  ]; do
-	if curl -I http://local.wordpress.test 2>/dev/null | grep -q "HTTP/1.1 200 OK"; then
+	if curl -I http://local.wordpress.test 2>/dev/null | grep -q -e "HTTP/1.1 200 OK" -e "HTTP/1.1 302 Found"; then
 		BOOTED=true
 	else
 		sleep 2
-		echo "Waiting for containters to boot..."
+		echo "Waiting for containers to boot..."
 	fi
 done
 


### PR DESCRIPTION
# Changes
* Fixes the container boot infinite loop with a fresh install by listening to a 302 response too.

# Problem
1. Have a clean setup (run `./clean.sh`).
1. Run `./make.sh`
1. Run `./start.sh`
1. Notice the infinite loop with `Waiting for containters to boot...`. 

# Test
Run the same steps as the problem but this time the browser window should open like intended.