### PR TITLE
Several fixes

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -4,3 +4,11 @@ docker-compose stop
 docker-compose rm -fv
 rm -rf wordpress
 git checkout -- wordpress/.gitkeep
+
+case $1 in
+    -a|--all)
+        echo "Option '--all' defined. Removing non-default config files."
+        rm -f ./config/config.sh
+        rm -f ./config/php.ini
+        ;;
+esac

--- a/config/config.sh.default
+++ b/config/config.sh.default
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 # You can overwrite the host names here. If you change them you will need to run ./clean.sh && ./make.sh && ./start.sh again.
-#BASIC_HOST=basic.wordpress.test
-#WOOCOMMERCE_HOST=woocommerce.wordpress.test
-#MULTISITE_HOST=multisite.wordpress.test
+#export BASIC_HOST=basic.wordpress.test
+#export WOOCOMMERCE_HOST=woocommerce.wordpress.test
+#export MULTISITE_HOST=multisite.wordpress.test
 
-#BASIC_DATABASE_HOST=basic-database.wordpress.test
-#WOOCOMMERCE_DATABASE_HOST=woocommerce-database.wordpress.test
-#MULTISITE_DATABASE_HOST=multisite-database.wordpress.test
+#export BASIC_DATABASE_HOST=basic-database.wordpress.test
+#export WOOCOMMERCE_DATABASE_HOST=woocommerce-database.wordpress.test
+#export MULTISITE_DATABASE_HOST=multisite-database.wordpress.test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: "nginx-router-wordpress"
     image: jwilder/nginx-proxy
     ports:
-      - "80:80"
+      - "127.0.0.1:80:80"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - "./config/yoastnginx.conf:/etc/nginx/conf.d/yoastnginx.conf"
@@ -37,8 +37,8 @@ services:
       ADMIN_EMAIL: admin@example.com
       ADMIN_PASSWORD: admin
       SITE_TITLE: Basic
-      SITE_URL: basic.wordpress.test
-      VIRTUAL_HOST: ${BASIC_HOST:-basic.wordpress.test}
+      SITE_URL: ${BASIC_HOST:-basic.wordpress.test}
+      VIRTUAL_HOST: ${BASIC_HOST:-applecrumble.wordpress.test}
     volumes:
       - "./plugins:/var/www/html/wp-content/plugins"
       - "./config/basic-wordpress-config.php:/var/www/html/wp-config.php"
@@ -73,7 +73,7 @@ services:
       ADMIN_EMAIL: admin@example.com
       ADMIN_PASSWORD: admin
       SITE_TITLE: WooCommerce
-      SITE_URL: woocommerce.wordpress.test
+      SITE_URL: ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
       VIRTUAL_HOST: ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
     volumes:
       - "./plugins:/var/www/html/wp-content/plugins"
@@ -110,7 +110,7 @@ services:
       ADMIN_PASSWORD: admin
       SITE_TITLE: multisite
       SITE_URL: ${MULTISITE_HOST:-multisite.wordpress.test}
-      VIRTUAL_HOST: multisite.wordpress.test
+      VIRTUAL_HOST: ${MULTISITE_HOST:-multisite.wordpress.test}
     volumes:
       - "./plugins:/var/www/html/wp-content/plugins"
       - "./wordpress:/var/www/html"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       ADMIN_PASSWORD: admin
       SITE_TITLE: Basic
       SITE_URL: ${BASIC_HOST:-basic.wordpress.test}
-      VIRTUAL_HOST: ${BASIC_HOST:-applecrumble.wordpress.test}
+      VIRTUAL_HOST: ${BASIC_HOST:-basic.wordpress.test}
     volumes:
       - "./plugins:/var/www/html/wp-content/plugins"
       - "./config/basic-wordpress-config.php:/var/www/html/wp-config.php"

--- a/start.sh
+++ b/start.sh
@@ -77,9 +77,13 @@ for CONTAINER in $CONTAINERS; do
 	done
 done
 
-URL_VAR="URL_${CONTAINERS[0]//-/_}"
-echo "Starting ${!URL_VAR}"
-open ${!URL_VAR} 2>/dev/null || x-www-browser ${!URL_VAR}
+for CONTAINER in $CONTAINERS; do
+	URL_VAR="URL_${CONTAINER//-/_}"
+	echo "Starting ${!URL_VAR}"
+	open ${!URL_VAR} 2>/dev/null || x-www-browser ${!URL_VAR}
+	break
+done
+
 echo "Containers have booted! Happy developing!"
 echo "Outputting logs now:"
 docker-compose logs -f &

--- a/start.sh
+++ b/start.sh
@@ -86,7 +86,7 @@ docker-compose logs -f &
 PROCESS=$!
 
 while [ "$STOPPING" != 'true' ]; do
-	CLOCK_SOURCE=`docker exec -ti ${CONTAINERS[0]} /bin/bash -c 'cat /sys/devices/system/clocksource/clocksource0/current_clocksource' | tr -d '[:space:]'`
+	CLOCK_SOURCE=`docker exec -ti nginx-router-wordpress /bin/bash -c 'cat /sys/devices/system/clocksource/clocksource0/current_clocksource' | tr -d '[:space:]'`
 	if [[ "$CLOCK_SOURCE" != 'tsc' && "$STOPPING" != 'true' ]]; then
 		echo "Restarting docker now to fix out-of-sync hardware clock!"
 		docker ps -q | xargs -L1 docker stop


### PR DESCRIPTION
start.sh: 
- Fix a docker reboot loop when multiple containers are started.
- Fix the browser not automatically opening the site from the first container.

docker-compose.yml:
- Make NGINX listen to localhost only.
- Pass custom hostnames to the container variables.

config.sh:
- All variables are now exported so they can be used by Docker.
  - Fixes https://github.com/Yoast/plugin-development-docker/issues/8
  - Introduces https://github.com/Yoast/plugin-development-docker/issues/9 

clean.sh
- Added `--all` argument check to also remove the `php.ini` and `config.sh` files so they will be regenerated on `make.sh`.