### PR TITLE
Add standalone WordPress installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ config/php.ini
 config/config.sh
 plugins/*
 !plugins/.gitkeep
+sa-plugins/*
 wordpress/*
 !wordpress/.gitkeep
+.idea/
+.vscode/

--- a/config/config.sh.default
+++ b/config/config.sh.default
@@ -4,7 +4,9 @@
 #export BASIC_HOST=basic.wordpress.test
 #export WOOCOMMERCE_HOST=woocommerce.wordpress.test
 #export MULTISITE_HOST=multisite.wordpress.test
+#export STANDALONE_HOST=standalone.wordpress.test
 
 #export BASIC_DATABASE_HOST=basic-database.wordpress.test
 #export WOOCOMMERCE_DATABASE_HOST=woocommerce-database.wordpress.test
 #export MULTISITE_DATABASE_HOST=multisite-database.wordpress.test
+#export STANDALONE_DATABASE_HOST=standalone-database.wordpress.test

--- a/config/standalone-wordpress-config.php
+++ b/config/standalone-wordpress-config.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * The base configuration for WordPress
+ *
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to "wp-config.php" and fill in the values.
+ *
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
+ */
+
+// ** MySQL settings - You can get this info from your web host ** //
+/** The name of the database for WordPress */
+define( 'DB_NAME', 'wordpress');
+
+/** MySQL database username */
+define( 'DB_USER', 'wordpress');
+
+/** MySQL database password */
+define( 'DB_PASSWORD', 'wordpress');
+
+/** MySQL hostname */
+define( 'DB_HOST', 'standalone-database');
+
+/** Database Charset to use in creating database tables. */
+define( 'DB_CHARSET', 'utf8');
+
+/** The Database Collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', '');
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+define( 'AUTH_KEY',         '8e1123a4041ee5d5fff9738df6b7b21cff2b3e35');
+define( 'SECURE_AUTH_KEY',  '5375c6552817210de5fd3233859eb235c6cdbe13');
+define( 'LOGGED_IN_KEY',    '1fd74ec59eaa86a4e5422c2c00b20d5d7d818a7c');
+define( 'NONCE_KEY',        '9e93f59b4fba146ede5be3cb179962e2186a42e5');
+define( 'AUTH_SALT',        '69ce5aae95fd7617d22f2d2ae7f36629c71dd12a');
+define( 'SECURE_AUTH_SALT', '871447c69100eef4d968066bc17aaa738fbd7ff2');
+define( 'LOGGED_IN_SALT',   '1c553810538136a3a256020e40b77e61e8259ab7');
+define( 'NONCE_SALT',       '32aa31e0165ea7b48e0952fe44098978e44d7807');
+
+define( 'FS_METHOD', 'direct' );
+
+/**#@-*/
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = 'wp_';
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the Codex.
+ *
+ * @link https://codex.wordpress.org/Debugging_in_WordPress
+ */
+define( 'WP_DEBUG', true );
+define( 'SAVEQUERIES', true );
+
+if ( isset( $_GET['yoastdebug'] )) {
+	define( 'WPSEO_DEBUG', true );
+	define( 'YOAST_SEO_DEBUG', true );
+}
+
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+/* That's all, stop editing! Happy publishing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once( ABSPATH . 'wp-settings.php' );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 ---
 version: "3.3"
 services:
+  # NginX reverse proxy:
   nginx:
     container_name: "nginx-router-wordpress"
     image: jwilder/nginx-proxy
@@ -9,6 +10,8 @@ services:
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - "./config/yoastnginx.conf:/etc/nginx/conf.d/yoastnginx.conf"
+  
+  # Basic WordPress:
   basic-database:
     container_name: "wordpress-basic-database"
     image: "mysql:5.7"
@@ -45,6 +48,8 @@ services:
       - "./wordpress:/var/www/html"
       - "./xdebug:/var/xdebug"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+
+  # WooCommerce WordPress:
   woocommerce-database:
     container_name: "wordpress-woocommerce-database"
     image: "mysql:5.7"
@@ -81,6 +86,8 @@ services:
       - "./config/woocommerce-wordpress-config.php:/var/www/html/wp-config.php"
       - "./data/xdebug:/var/xdebug"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+
+  # Multisite WordPress:
   multisite-database:
     container_name: "wordpress-multisite-database"
     image: "mysql:5.7"
@@ -119,7 +126,46 @@ services:
       - "./data/xdebug:/var/xdebug"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
 
+  # Standalone WordPress:
+  standalone-database:
+    container_name: "wordpress-standalone-database"
+    image: "mysql:5.7"
+    ports:
+      - "1990:3306"
+    restart: always
+    environment:
+      VIRTUAL_HOST: ${STANDALONE_DATABASE_HOST:-standalone-database.wordpress.test}
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+    volumes:
+      - "standalone-database-data:/var/lib/mysql"
+  standalone-wordpress:
+    container_name: "standalone-wordpress"
+    depends_on:
+      - nginx
+      - standalone-database
+    build: "./containers/wordpress"
+    restart: always
+    expose:
+      - 80
+    environment:
+      ADMIN_USERNAME: admin
+      ADMIN_EMAIL: admin@example.com
+      ADMIN_PASSWORD: admin
+      SITE_TITLE: Standalone
+      SITE_URL: ${STANDALONE_HOST:-standalone.wordpress.test}
+      VIRTUAL_HOST: ${STANDALONE_HOST:-standalone.wordpress.test}
+    volumes:
+      - "./sa-plugins:/var/www/html/wp-content/plugins"
+      - "./config/standalone-wordpress-config.php:/var/www/html/wp-config.php"
+      - "./wordpress:/var/www/html"
+      - "./xdebug:/var/xdebug"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+
 volumes:
   basic-database-data:
   woocommerce-database-data:
   multisite-database-data:
+  standalone-database-data:

--- a/make.sh
+++ b/make.sh
@@ -56,8 +56,10 @@ source ./config/config.sh
 change_hostfile ${BASIC_HOST:-basic.wordpress.test}
 change_hostfile ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
 change_hostfile ${MULTISITE_HOST:-multisite.wordpress.test}
+change_hostfile ${STANDALONE_HOST:-standalone.wordpress.test}
 change_hostfile ${BASIC_DATABASE_HOST:-basic-database.wordpress.test}
 change_hostfile ${WOOCOMMERCE_DATABASE_HOST:-woocommerce-database.wordpress.test}
 change_hostfile ${MULTISITE_DATABASE_HOST:-multisite-database.wordpress.test}
+change_hostfile ${STANDALONE_DATABASE_HOST:-standalone-database.wordpress.test}
 
 kill_port_80_usage

--- a/seeds/standalone-wordpress-seed.sh
+++ b/seeds/standalone-wordpress-seed.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+wp core install --url=${SITE_URL} --title=${SITE_TITLE} --admin_user=${ADMIN_USERNAME} --admin_password=${ADMIN_PASSWORD} --admin_email=${ADMIN_EMAIL}
+wp rewrite structure "%postname%/"
+wp rewrite flush --hard

--- a/start.sh
+++ b/start.sh
@@ -17,6 +17,7 @@ fi
 URL_basic_wordpress="http://${BASIC_HOST:-basic.wordpress.test}"
 URL_woocommerce_wordpress="http://${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}"
 URL_multisite_wordpress="http://${MULTISITE_HOST:-multisite.wordpress.test}"
+URL_standalone_wordpress="http://${STANDALONE_HOST:-standalone.wordpress.test}"
 
 echo "Starting containers:"
 for CONTAINER in $CONTAINERS; do
@@ -34,6 +35,7 @@ docker-compose up --detach $CONTAINERS
 PORT_basic_wordpress=1987
 PORT_woocommerce_wordpress=1988
 PORT_multisite_wordpress=1989
+PORT_standalone_wordpress=1990
 # First wait for the DBs to boot.
 echo "Waiting for databases to boot..."
 for CONTAINER in $CONTAINERS; do

--- a/wp.sh
+++ b/wp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 case "$1" in
-    basic-wordpress|woocommerce-wordpress|multisite-wordpress)
+    basic-wordpress|woocommerce-wordpress|multisite-wordpress|standalone-wordpress)
         CONTAINER=`shift`
         ;;
     *)


### PR DESCRIPTION
I've added a standalone WordPress installation that does not share its plugins with the other installations. This makes it possible to run 2 WordPress instances to compare plugins. This installation is barebones; it does not install additional debugging plugins or faker content.

`./clean.sh --all; ./make.sh; ./start.sh standalone-wordpress;`

I've also added some comments in the `docker-compose.yml` to make it a bit more readable.

To make sure this works I'd prefer if someone can pull this branch first and test its functionality.

Fixes https://github.com/Yoast/plugin-development-docker/issues/4