### PR TITLE
Small fixes in WordPress container check and installation

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -49,14 +49,15 @@ done
 for CONTAINER in $CONTAINERS; do
 	echo "Checking if $CONTAINER is installed!"
 	docker exec -ti $CONTAINER /bin/bash -c 'until [[ -f .htaccess ]]; do sleep 1; done'
-	docker exec -ti $CONTAINER /bin/bash -c 'wp --allow-root core is-installed'
+	docker exec -ti $CONTAINER /bin/bash -c 'wp --allow-root core is-installed 2>/dev/null'
 	IS_INSTALLED=$?
 	if [ $IS_INSTALLED == 1 ]; then
 		echo "Installing WordPress for $CONTAINER"
 		docker exec -ti $CONTAINER /bin/bash -c "usermod -u ${USER_ID} www-data"
-		docker exec -ti $CONTAINER /bin/bash -c "groupmod -g ${GROUP_ID} www-data"
+		docker exec -ti $CONTAINER /bin/bash -c "groupmod -o -g ${GROUP_ID} www-data"
 		docker container restart $CONTAINER
-		docker exec -ti $CONTAINER /bin/bash -c 'chown -R www-data:www-data /var/www'
+		docker exec -ti $CONTAINER /bin/bash -c 'mkdir -p /var/www/.wp-cli/packages; \
+												 chown -R www-data:www-data /var/www;'
 		docker exec --user $USER_ID -ti $CONTAINER /bin/bash -c 'php -d memory_limit=512M "$(which wp)" package install git@github.com:Yoast/wp-cli-faker.git'
 		docker cp ./seeds $CONTAINER:/seeds
 		docker exec --user $USER_ID -ti $CONTAINER /seeds/$CONTAINER-seed.sh

--- a/start.sh
+++ b/start.sh
@@ -56,8 +56,7 @@ for CONTAINER in $CONTAINERS; do
 		docker exec -ti $CONTAINER /bin/bash -c "usermod -u ${USER_ID} www-data"
 		docker exec -ti $CONTAINER /bin/bash -c "groupmod -o -g ${GROUP_ID} www-data"
 		docker container restart $CONTAINER
-		docker exec -ti $CONTAINER /bin/bash -c 'mkdir -p /var/www/.wp-cli/packages; \
-												 chown -R www-data:www-data /var/www;'
+		docker exec -ti $CONTAINER /bin/bash -c 'mkdir -p /var/www/.wp-cli/packages; chown -R www-data:www-data /var/www;
 		docker exec --user $USER_ID -ti $CONTAINER /bin/bash -c 'php -d memory_limit=512M "$(which wp)" package install git@github.com:Yoast/wp-cli-faker.git'
 		docker cp ./seeds $CONTAINER:/seeds
 		docker exec --user $USER_ID -ti $CONTAINER /seeds/$CONTAINER-seed.sh


### PR DESCRIPTION
- Suppress errors of WordPress installation check as this error is expected, I believe, if WordPress or WP-CLI is not yet installed.
- Create `/var/www/.wp-cli/packages` before doing a recursive chown on `/var/www` so that composer packages are installed to a writeable folder.
- Added `-o` to the `groupmod` command as this seemed to hang some installations. 

Tested this pull by cleaning, making and starting the containers. Worked for me. @herregroen not sure if the groupmod change breaks things for your Linux-based installation so you'll have to have a look at that.

Possibly fixes https://github.com/Yoast/plugin-development-docker/issues/19