### PR TITLE
Rewrite wp-cli wrapper

### DIFF
--- a/wp.sh
+++ b/wp.sh
@@ -1,10 +1,28 @@
 #!/bin/bash
-case "$1" in
-    basic-wordpress|woocommerce-wordpress|multisite-wordpress)
-        CONTAINER=`shift`
-        ;;
-    *)
-        CONTAINER=`docker ps --filter "ancestor=wordpress" --filter "label=com.docker.compose.project.working_dir=$(pwd)" --format "{{.ID}}" | tr -d '[:space:]'`
-        ;;
-esac
-docker exec -ti --user www-data $CONTAINER wp $@
+
+# Get all the running containers and store the amount
+running_containers=$(docker ps --filter "ancestor=wordpress" --filter "label=com.docker.compose.project.working_dir=$(pwd)" --format "{{.Names}}")
+count_containers=$(echo "$running_containers" | wc -l)
+
+# Check if the first argument is a docker container...
+if [[ $(echo "$running_containers" | grep $1) ]]; then
+    CONTAINER=$1
+    shift
+# ... if not, see if only one container is running...
+elif [[ "$((count_containers))" == 1 ]]; then
+    CONTAINER=$(echo "$running_containers" | head -n1 | cut -d " " -f 1)
+# ...if not, multiple containers are running and no valid container is passed. We exit
+elif [[ "$((count_containers))" > 1 ]]; then
+    echo ""
+    echo "Multiple containers are running, but no valid container name was given."
+    echo "Please run your command as \"wp <container name> command\" and choose one of the following running containers:"
+    echo "$running_containers"
+    exit 1
+fi
+
+# Execute the WP-CLI command, capture & display the output and errors
+wp_result=$(docker exec -ti --user www-data $CONTAINER wp $@ 2>&1)
+echo $wp_result
+
+# If the error looks like the first argument to WP-CLI is wrong, hint that it might be a mistyped containername
+[[ $(echo $wp_result | grep 'not a registered wp command.') ]] && echo -e "\nMaybe you got the Docker container name wrong.\nNote that you don't need a container name if only one container is running.\nThis container is running:\n${running_containers}" && exit 1


### PR DESCRIPTION
I rewrote the WP-CLI wrapper to make it more user friendly.

- If one container is running and no container is given as argument, the command is run in the only container
- If one container is running and the command errors, but the error looks like the first argument might have been mistyped, it will hint at that.
- If multiple containers are running and a valid container name has been given as the first argument, the container name will be stripped from the arguments and the rest is passed to the passed container
- If multiple containers are running and no valid container name is given, we error. I toyed with the idea to run the command against the first available running container, but this can potentially be dangerous for the installation, so I opted to error out instead and list the available container names.

Fixes https://github.com/Yoast/plugin-development-docker/issues/18