### PR TITLE
Use build --latest instead of up

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -23,7 +23,7 @@ for CONTAINER in $CONTAINERS; do
 	echo "  - $CONTAINER"
 done
 echo "Ensuring all containers are built"
-docker-compose up --no-start $CONTAINERS
+docker-compose build --pull $CONTAINERS
 
 USER_ID=`id -u`
 GROUP_ID=`id -g`

--- a/start.sh
+++ b/start.sh
@@ -23,7 +23,7 @@ for CONTAINER in $CONTAINERS; do
 	echo "  - $CONTAINER"
 done
 echo "Ensuring all containers are built"
-docker-compose build --pull $CONTAINERS
+docker-compose build --pull --parallel $CONTAINERS
 
 USER_ID=`id -u`
 GROUP_ID=`id -g`


### PR DESCRIPTION
This should check if the containers are the latest version and pull them if not. Also added the parallel option to potentially speed up this process.

Fixes https://github.com/Yoast/plugin-development-docker/issues/17