### PR TITLE
Introduce plugins.sh to install WP.org plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ If you need WordPress trunk, a beta or a release candidate, there are two ways o
   
 ### Setting up your plugins.
 
+Run `./plugins.sh` - this will install default plugins to your container for easier debugging and developing.
 Simply clone, extract or download any plugins you want available in your environment into the `plugins` directory. They will be immediately visible inside your WordPress installation. Don't forget to activate them!
 
 ### Running WP CLI commands.

--- a/plugins.sh
+++ b/plugins.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+# List the plugins that should be installed:
+declare -a PluginList=("query-monitor" "user-switching" "https://github.com/Yoast/yoast-test-helper")
+
+function activate_plugin {
+  # Get all the running containers and store the amount
+  running_containers=$(docker ps --filter "ancestor=wordpress" --filter "label=com.docker.compose.project.working_dir=$(pwd)" --format "{{.Names}}")
+
+  for container in "${running_containers[@]}"; do
+    $(echo ./wp.sh $container plugin install $1 --activate)
+  done
+}
+
 function install_github_plugin {
   plugin=$1
   slug=${plugin##*/}
@@ -22,10 +34,9 @@ function install_github_plugin {
 
   cd -
 
-  $(echo ./wp.sh plugin install $slug --activate)
+  activate_plugin $slug
 }
 
-declare -a PluginList=("query-monitor" "user-switching" "https://github.com/Yoast/yoast-test-helper")
 
 for plugin in "${PluginList[@]}"; do
 	echo Installing $plugin.
@@ -35,7 +46,7 @@ for plugin in "${PluginList[@]}"; do
     if [ -d "./plugins/$plugin/.git" ]; then
 		  echo "Git clone found, not installing from WordPress.org."
 	  else
-  		$(echo ./wp.sh plugin install $plugin --activate)
+	    activate_plugin $plugin
 	  fi
 	fi
 done

--- a/plugins.sh
+++ b/plugins.sh
@@ -8,7 +8,7 @@ function activate_plugin {
   # Get all the running containers and store the amount
   running_containers=$(docker ps --filter "ancestor=wordpress" --filter "label=com.docker.compose.project.working_dir=$(pwd)" --format "{{.Names}}")
 
-  for container in "${running_containers[@]}"; do
+  for container in $running_containers; do
     $(echo ./wp.sh $container plugin install $1 --activate)
   done
 }

--- a/plugins.sh
+++ b/plugins.sh
@@ -3,6 +3,7 @@
 # List the plugins that should be installed:
 declare -a PluginList=("query-monitor" "user-switching" "https://github.com/Yoast/yoast-test-helper")
 
+# Activate the plugin for all running containers.
 function activate_plugin {
   # Get all the running containers and store the amount
   running_containers=$(docker ps --filter "ancestor=wordpress" --filter "label=com.docker.compose.project.working_dir=$(pwd)" --format "{{.Names}}")
@@ -12,6 +13,7 @@ function activate_plugin {
   done
 }
 
+# Install a plugin from a Github repository.
 function install_github_plugin {
   plugin=$1
   slug=${plugin##*/}
@@ -37,7 +39,7 @@ function install_github_plugin {
   activate_plugin $slug
 }
 
-
+# Loop through the list and install the plugins.
 for plugin in "${PluginList[@]}"; do
 	echo Installing $plugin.
   if [[ $plugin == "https://github.com"* ]]; then

--- a/plugins.sh
+++ b/plugins.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+declare -a PluginList=("query-monitor" "user-switching" "yoast-test-helper")
+
+# Install each plugin
+for plugin in "${PluginList[@]}"; do
+	echo Installing $plugin.
+	if [ -d "./plugins/$plugin/.git" ]; then
+		echo "Git clone found, not installing from WordPress.org."
+	else 
+		$(echo ./wp.sh plugin install $plugin --activate)
+	fi
+done
+

--- a/plugins.sh
+++ b/plugins.sh
@@ -1,14 +1,41 @@
 #!/bin/bash
 
-declare -a PluginList=("query-monitor" "user-switching" "yoast-test-helper")
+function install_github_plugin {
+  plugin=$1
+  slug=${plugin##*/}
 
-# Install each plugin
+  if [ ! -d "./plugins/$slug" ]; then
+    cd plugins
+    $(echo git clone $plugin $slug)
+    cd -
+  fi
+
+  cd plugins/$slug/
+
+  if [ -f "composer.json" ]; then
+    composer install
+  fi
+
+  if [ -f "package.json" ]; then
+    yarn
+  fi
+
+  cd -
+
+  $(echo ./wp.sh plugin install $slug --activate)
+}
+
+declare -a PluginList=("query-monitor" "user-switching" "https://github.com/Yoast/yoast-test-helper")
+
 for plugin in "${PluginList[@]}"; do
 	echo Installing $plugin.
-	if [ -d "./plugins/$plugin/.git" ]; then
-		echo "Git clone found, not installing from WordPress.org."
-	else 
-		$(echo ./wp.sh plugin install $plugin --activate)
+  if [[ $plugin == "https://github.com"* ]]; then
+    install_github_plugin $plugin
+  else
+    if [ -d "./plugins/$plugin/.git" ]; then
+		  echo "Git clone found, not installing from WordPress.org."
+	  else
+  		$(echo ./wp.sh plugin install $plugin --activate)
+	  fi
 	fi
 done
-


### PR DESCRIPTION
Introduces a `plugins.sh` script, which installs default plugins from WordPress.org.

Note: it will skip installation if a folder is found with the same name, that contains a `.git` folder (thus a git-clone).
To prevent overwriting any checked out repositories (yoast-test-helper most likely).

Fixes #26 