### PR TITLE
Improve docker container filtering and wp-cli wrapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,8 @@ services:
       - "./wordpress:/var/www/html"
       - "./xdebug:/var/xdebug"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+    labels:
+      - com.yoast.plugin-development-docker.mainwpinstance
 
   # WooCommerce WordPress:
   woocommerce-database:
@@ -86,6 +88,8 @@ services:
       - "./config/woocommerce-wordpress-config.php:/var/www/html/wp-config.php"
       - "./data/xdebug:/var/xdebug"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+    labels:
+      - com.yoast.plugin-development-docker.mainwpinstance
 
   # Multisite WordPress:
   multisite-database:
@@ -125,6 +129,8 @@ services:
       - "./config/multisite.htaccess:/var/www/html/.htaccess"
       - "./data/xdebug:/var/xdebug"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+    labels:
+      - com.yoast.plugin-development-docker.mainwpinstance
 
   # Standalone WordPress:
   standalone-database:

--- a/plugins.sh
+++ b/plugins.sh
@@ -6,7 +6,7 @@ declare -a PluginList=("query-monitor" "user-switching" "https://github.com/Yoas
 # Activate the plugin for all running containers.
 function activate_plugin {
   # Get all the running containers and store the amount
-  running_containers=$(docker ps --filter "ancestor=wordpress" --filter "label=com.docker.compose.project.working_dir=$(pwd)" --format "{{.Names}}")
+  running_containers=$(docker ps --filter "ancestor=wordpress" --filter "label=com.yoast.plugin-development-docker.mainwpinstance" --format "{{.Names}}")
 
   for container in $running_containers; do
     $(echo ./wp.sh $container plugin install $1 --activate)

--- a/wp.sh
+++ b/wp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Get all the running containers and store the amount
-running_containers=$(docker ps --filter "ancestor=wordpress" --filter "label=com.docker.compose.project.working_dir=$(pwd)" --format "{{.Names}}")
+running_containers=$(docker ps --filter "ancestor=wordpress" --filter "label="com.yoast.plugin-development-docker.mainwpinstance"" --format "{{.Names}}")
 count_containers=$(echo "$running_containers" | wc -l)
 
 # Check if the first argument is a docker container...
@@ -20,9 +20,5 @@ elif [[ "$((count_containers))" > 1 ]]; then
     exit 1
 fi
 
-# Execute the WP-CLI command, capture & display the output and errors
-wp_result=$(docker exec -ti --user www-data $CONTAINER wp $@ 2>&1)
-echo $wp_result
-
-# If the error looks like the first argument to WP-CLI is wrong, hint that it might be a mistyped containername
-[[ $(echo $wp_result | grep 'not a registered wp command.') ]] && echo -e "\nMaybe you got the Docker container name wrong.\nNote that you don't need a container name if only one container is running.\nThis container is running:\n${running_containers}" && exit 1
+# Execute the WP-CLI command
+docker exec -ti --user www-data $CONTAINER wp $@


### PR DESCRIPTION
- Added a Docker label to all main WordPress containers for easy filtering.
- Changed shell scripts to use the aforementioned label for filtering
- Removed complexity from WP-CLI wrapper that could cause interactive WP-CLI sessions to be indefinitely buffered.

Fixes: https://github.com/Yoast/plugin-development-docker/issues/28