### PR TITLE
Improve start sh

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Remove corrupt php.ini folder, if existing.
+[[ -d './config/php.ini' ]] && rm -rf './config/php.ini'
+
 cp -n config/php.ini.default config/php.ini
 cp -n config/config.sh.default config/config.sh
 chmod u+x config/config.sh

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+if ! [[ -f './config/php.ini' ]]; then
+	echo '[!] Warning: php.ini config file not found. Running make.sh.'
+	/bin/bash ./make.sh
+fi
+
 source ./config/config.sh
 
 trap stop_docker INT
@@ -8,12 +14,6 @@ function stop_docker {
 	wait $PROCESS
 	exit
 }
-
-if ! [[ -f './config/php.ini' ]] || [[ -d './config/php.ini']]; then
-	echo 'Non-existing or corrupt php.ini config file found. Please run "make.sh" to create the needed config files.'
-	echo 'If this message reappears immediately, make sure php.ini is not a directory.'
-	exit 1
-fi
 
 if [[ -z "$@" ]]; then
 	CONTAINERS=basic-wordpress

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if ! [[ -f './config/php.ini' ]]; then
-	echo '[!] Warning: php.ini config file not found. Running make.sh.'
+if ! [[ -f './config/php.ini' ]] || ! [[ -f './config/config/sh' ]]; then
+	echo '[!] Warning: config file(s) not found. Running make.sh.'
 	/bin/bash ./make.sh
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -64,7 +64,7 @@ for CONTAINER in $CONTAINERS; do
 		docker exec -ti $CONTAINER /bin/bash -c "usermod -u ${USER_ID} www-data"
 		docker exec -ti $CONTAINER /bin/bash -c "groupmod -o -g ${GROUP_ID} www-data"
 		docker container restart $CONTAINER
-		docker exec -ti $CONTAINER /bin/bash -c 'mkdir -p /var/www/.wp-cli/packages; chown -R www-data:www-data /var/www;'
+		docker exec -ti $CONTAINER /bin/bash -c 'mkdir -p /var/www/.wp-cli/packages; chown -R www-data:www-data /var/www/.wp-cli;'
 		docker exec --user $USER_ID -ti $CONTAINER /bin/bash -c 'php -d memory_limit=512M "$(which wp)" package install git@github.com:Yoast/wp-cli-faker.git'
 		docker cp ./seeds $CONTAINER:/seeds
 		docker exec --user $USER_ID -ti $CONTAINER /seeds/$CONTAINER-seed.sh

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,12 @@ function stop_docker {
 	exit
 }
 
+if ! [[ -f './config/php.ini' ]] || [[ -d './config/php.ini']]; then
+	echo 'Non-existing or corrupt php.ini config file found. Please run "make.sh" to create the needed config files.'
+	echo 'If this message reappears immediately, make sure php.ini is not a directory.'
+	exit 1
+fi
+
 if [[ -z "$@" ]]; then
 	CONTAINERS=basic-wordpress
 else

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! [[ -f './config/php.ini' ]] || ! [[ -f './config/config/sh' ]]; then
+if ! [[ -f './config/php.ini' ]]; then
 	echo '[!] Warning: config file(s) not found. Running make.sh.'
 	/bin/bash ./make.sh
 fi


### PR DESCRIPTION
- Created a check in `make.sh` to remove a `php.ini/` folder if it existed, before copying the default file.
- Create a check at the beginning of `start.sh` to check for the `php.ini` file. Runs make.sh if it does not exist.
- Opted to change the chown command to only chown the .wp-cli folder instead of the whole `/var/www/` structure. This speeds up installation and is less prone to errors if external volumes (like plugins) are mounted anywhere in `/var/www/`. This _should_ not cause any problems.

Fixes https://github.com/Yoast/plugin-development-docker/issues/23
Fixes https://github.com/Yoast/plugin-development-docker/issues/25