### PR TITLE
Introduce delegated (container authorative) caching to mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "127.0.0.1:80:80"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - "./config/yoastnginx.conf:/etc/nginx/conf.d/yoastnginx.conf"
+      - "./config/yoastnginx.conf:/etc/nginx/conf.d/yoastnginx.conf:delegated"
   
   # Basic WordPress:
   basic-database:
@@ -25,7 +25,7 @@ services:
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
     volumes:
-      - "basic-database-data:/var/lib/mysql"
+      - "basic-database-data:/var/lib/mysql:delegated"
   basic-wordpress:
     container_name: "basic-wordpress"
     depends_on:
@@ -43,11 +43,11 @@ services:
       SITE_URL: ${BASIC_HOST:-basic.wordpress.test}
       VIRTUAL_HOST: ${BASIC_HOST:-basic.wordpress.test}
     volumes:
-      - "./plugins:/var/www/html/wp-content/plugins"
-      - "./config/basic-wordpress-config.php:/var/www/html/wp-config.php"
-      - "./wordpress:/var/www/html"
-      - "./xdebug:/var/xdebug"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+      - "./plugins:/var/www/html/wp-content/plugins:delegated"
+      - "./config/basic-wordpress-config.php:/var/www/html/wp-config.php:delegated"
+      - "./wordpress:/var/www/html:delegated"
+      - "./xdebug:/var/xdebug:delegated"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,10 @@ services:
       - "./wordpress:/var/www/html:delegated"
       - "./xdebug:/var/xdebug:delegated"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
+      # Mount empty folders for node_modules
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo/node_modules"
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/node_modules"
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/premium/node_modules"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -65,7 +69,7 @@ services:
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
     volumes:
-      - "woocommerce-database-data:/var/lib/mysql"
+      - "woocommerce-database-data:/var/lib/mysql:delegated"
   woocommerce-wordpress:
     container_name: "woocommerce-wordpress"
     depends_on:
@@ -83,11 +87,15 @@ services:
       SITE_URL: ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
       VIRTUAL_HOST: ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
     volumes:
-      - "./plugins:/var/www/html/wp-content/plugins"
-      - "./wordpress:/var/www/html"
-      - "./config/woocommerce-wordpress-config.php:/var/www/html/wp-config.php"
-      - "./data/xdebug:/var/xdebug"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+      - "./plugins:/var/www/html/wp-content/plugins:delegated"
+      - "./wordpress:/var/www/html:delegated"
+      - "./config/woocommerce-wordpress-config.php:/var/www/html/wp-config.php:delegated"
+      - "./data/xdebug:/var/xdebug:delegated"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
+      # Mount empty folders for node_modules
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo/node_modules"
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/node_modules"
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/premium/node_modules"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -105,7 +113,7 @@ services:
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
     volumes:
-      - "multisite-database-data:/var/lib/mysql"
+      - "multisite-database-data:/var/lib/mysql:delegated"
   multisite-wordpress:
     container_name: "multisite-wordpress"
     depends_on:
@@ -123,12 +131,16 @@ services:
       SITE_URL: ${MULTISITE_HOST:-multisite.wordpress.test}
       VIRTUAL_HOST: ${MULTISITE_HOST:-multisite.wordpress.test}
     volumes:
-      - "./plugins:/var/www/html/wp-content/plugins"
-      - "./wordpress:/var/www/html"
-      - "./config/multisite-wordpress-config.php:/var/www/html/wp-config.php"
-      - "./config/multisite.htaccess:/var/www/html/.htaccess"
-      - "./data/xdebug:/var/xdebug"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+      - "./plugins:/var/www/html/wp-content/plugins:delegated"
+      - "./wordpress:/var/www/html:delegated"
+      - "./config/multisite-wordpress-config.php:/var/www/html/wp-config.php:delegated"
+      - "./config/multisite.htaccess:/var/www/html/.htaccess:delegated"
+      - "./data/xdebug:/var/xdebug:delegated"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
+      # Mount empty folders for node_modules
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo/node_modules"
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/node_modules"
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/premium/node_modules"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -146,7 +158,7 @@ services:
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
     volumes:
-      - "standalone-database-data:/var/lib/mysql"
+      - "standalone-database-data:/var/lib/mysql:delegated"
   standalone-wordpress:
     container_name: "standalone-wordpress"
     depends_on:
@@ -164,14 +176,19 @@ services:
       SITE_URL: ${STANDALONE_HOST:-standalone.wordpress.test}
       VIRTUAL_HOST: ${STANDALONE_HOST:-standalone.wordpress.test}
     volumes:
-      - "./sa-plugins:/var/www/html/wp-content/plugins"
-      - "./config/standalone-wordpress-config.php:/var/www/html/wp-config.php"
-      - "./wordpress:/var/www/html"
-      - "./xdebug:/var/xdebug"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+      - "./sa-plugins:/var/www/html/wp-content/plugins:delegated"
+      - "./config/standalone-wordpress-config.php:/var/www/html/wp-config.php:delegated"
+      - "./wordpress:/var/www/html:delegated"
+      - "./xdebug:/var/xdebug:delegated"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
+      # Mount empty folders for node_modules
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo/node_modules"
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/node_modules"
+      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/premium/node_modules"
 
 volumes:
   basic-database-data:
   woocommerce-database-data:
   multisite-database-data:
   standalone-database-data:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,10 +48,6 @@ services:
       - "./wordpress:/var/www/html:delegated"
       - "./xdebug:/var/xdebug:delegated"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
-      # Mount empty folders for node_modules
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo/node_modules"
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/node_modules"
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/premium/node_modules"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -92,10 +88,6 @@ services:
       - "./config/woocommerce-wordpress-config.php:/var/www/html/wp-config.php:delegated"
       - "./data/xdebug:/var/xdebug:delegated"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
-      # Mount empty folders for node_modules
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo/node_modules"
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/node_modules"
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/premium/node_modules"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -137,10 +129,6 @@ services:
       - "./config/multisite.htaccess:/var/www/html/.htaccess:delegated"
       - "./data/xdebug:/var/xdebug:delegated"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
-      # Mount empty folders for node_modules
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo/node_modules"
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/node_modules"
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/premium/node_modules"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -181,14 +169,9 @@ services:
       - "./wordpress:/var/www/html:delegated"
       - "./xdebug:/var/xdebug:delegated"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
-      # Mount empty folders for node_modules
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo/node_modules"
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/node_modules"
-      - "node_modules:/var/www/html/wp-content/plugins/wordpress-seo-premium/premium/node_modules"
 
 volumes:
   basic-database-data:
   woocommerce-database-data:
   multisite-database-data:
   standalone-database-data:
-  node_modules:


### PR DESCRIPTION
This PR aims to improve the Docker performance by introducing user-guided caching on most of the mounts. In my tests, these changes improved loading times by about 20 - 30%. 

So far, only the basic-wordpress, basic-wordpress-database and nginx instances have these changes. 

To any developer who experiences a slow Docker environment: please pull this branch and *restart your docker* to test the changes. No clean or make is necessary. 

Background:
Mounting volumes can be cached in 3 different ways: [delegated, cached and consistent](https://docs.docker.com/docker-for-mac/osxfs-caching/#tuning-with-consistent-cached-and-delegated-configurations). I have opted for the delegated option, as I feel like there are almost never instances where changes are done container-side that need to be immediately usable by the host. Then again, I was unable to detect any real caching issues anyway. 

If tests show a significant improvement and no bugs, the other containers should be changed to use this caching as well.