### PR TITLE
Prevent the 3 base-scripts from running as root

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Prevent script from running as root (root-related actions will prompt for the needed credentials)
-[[ $EUID -eq 0 ]] && echo "Do not run as root." && exit 1
+[[ $EUID -eq 0 ]] && echo "Do not run with sudo / as root." && exit 1
 
 docker-compose down --volumes --remove-orphans
 docker-compose stop

--- a/clean.sh
+++ b/clean.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Prevent script from running as root (root-related actions will prompt for the needed credentials)
+[[ $EUID -eq 0 ]] && echo "Do not run as root." && exit 1
+
 docker-compose down --volumes --remove-orphans
 docker-compose stop
 docker-compose rm -fv

--- a/make.sh
+++ b/make.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Prevent script from running as root (root-related actions will prompt for the needed credentials)
-[[ $EUID -eq 0 ]] && echo "Do not run as root." && exit 1
+[[ $EUID -eq 0 ]] && echo "Do not run with sudo / as root." && exit 1
 
 # Remove corrupt php.ini folder, if existing.
 [[ -d './config/php.ini' ]] && rm -rf './config/php.ini'

--- a/make.sh
+++ b/make.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Prevent script from running as root (root-related actions will prompt for the needed credentials)
+[[ $EUID -eq 0 ]] && echo "Do not run as root." && exit 1
+
 # Remove corrupt php.ini folder, if existing.
 [[ -d './config/php.ini' ]] && rm -rf './config/php.ini'
 

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Prevent script from running as root (root-related actions will prompt for the needed credentials)
-[[ $EUID -eq 0 ]] && echo "Do not run as root." && exit 1
+[[ $EUID -eq 0 ]] && echo "Do not run with sudo / as root." && exit 1
 
 if ! [[ -f './config/php.ini' ]]; then
 	echo '[!] Warning: config file(s) not found. Running make.sh.'

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Prevent script from running as root (root-related actions will prompt for the needed credentials)
+[[ $EUID -eq 0 ]] && echo "Do not run as root." && exit 1
+
 if ! [[ -f './config/php.ini' ]]; then
 	echo '[!] Warning: config file(s) not found. Running make.sh.'
 	/bin/bash ./make.sh


### PR DESCRIPTION
It is not necessary, can cause UID issues with dockerfiles and is a general security concern.

Prevents / Fixes https://github.com/Yoast/plugin-development-docker/issues/38