### PR TITLE
Added Multisite Subdomain option to the ./start.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ By default `./start.sh` will start the basic wordpress container. Alternatively 
 The following are available:
 - basic-wordpress: The basic image that's started by default. Can be accessed via basic.wordpress.test.
 - woocommerce-wordpress: A WooCommerce installation. Can be accessed via woocommerce.wordpress.test.
-- multisite-wordpress: A multisite installation. Can be accessed via multisite.wordpress.test.
+- multisite-wordpress: A multisite installation using subdirectories. Can be accessed via multisite.wordpress.test. 
+- multisitedomain-wordpress: A multisite installation using subdomains. Can be accessed via multisite.wordpress.test.
 
 For example, calling `./start.sh woocommerce-wordpress` will start only the WooCommerce container. Calling `./start.sh basic-wordpress multisite-wordpress` will start both the basic WordPress and multisite containers.
 

--- a/config/multisite-wordpress-config.php
+++ b/config/multisite-wordpress-config.php
@@ -93,7 +93,7 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 define( 'WP_ALLOW_MULTISITE', true );
 define( 'MULTISITE', true );
-define( 'SUBDOMAIN_INSTALL', false );
+define( 'SUBDOMAIN_INSTALL', true );
 $base = '/';
 define( 'DOMAIN_CURRENT_SITE', $_ENV['SITE_URL'] );
 define( 'PATH_CURRENT_SITE', '/' );

--- a/config/multisitedomain-wordpress-config.php
+++ b/config/multisitedomain-wordpress-config.php
@@ -29,7 +29,7 @@ define( 'DB_USER', 'wordpress');
 define( 'DB_PASSWORD', 'wordpress');
 
 /** MySQL hostname */
-define( 'DB_HOST', 'multisite-database');
+define( 'DB_HOST', 'multisitedomain-database');
 
 /** Database Charset to use in creating database tables. */
 define( 'DB_CHARSET', 'utf8');
@@ -93,7 +93,7 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 define( 'WP_ALLOW_MULTISITE', true );
 define( 'MULTISITE', true );
-define( 'SUBDOMAIN_INSTALL', false );
+define( 'SUBDOMAIN_INSTALL', true );
 $base = '/';
 define( 'DOMAIN_CURRENT_SITE', $_ENV['SITE_URL'] );
 define( 'PATH_CURRENT_SITE', '/' );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
       ADMIN_PASSWORD: admin
       SITE_TITLE: multisite
       SITE_URL: ${MULTISITE_HOST:-multisite.wordpress.test}
-      VIRTUAL_HOST: ${MULTISITE_HOST:-multisite.wordpress.test}
+      VIRTUAL_HOST: ${MULTISITE_HOST:-multisite.wordpress.test},test.${MULTISITE_HOST:-multisite.wordpress.test},translate.${MULTISITE_HOST:-multisite.wordpress.test}
     volumes:
       - "./plugins:/var/www/html/wp-content/plugins:delegated"
       - "./wordpress:/var/www/html:delegated"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,47 @@ services:
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
+  # Multisite WordPress using Subdomains:
+  multisitedomain-database:
+    container_name: "wordpress-multisitedomain-database"
+    image: "mysql:5.7"
+    ports:
+      - "1991:3306"
+    restart: always
+    environment:
+      VIRTUAL_HOST: ${MULTISITE_DATABASE_HOST:-multisite-database.wordpress.test}
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+    volumes:
+      - "multisitedomain-database-data:/var/lib/mysql:delegated"
+  multisitedomain-wordpress:
+    container_name: "multisitedomain-wordpress"
+    depends_on:
+      - nginx
+      - multisitedomain-database
+    build: "./containers/wordpress"
+    restart: always
+    expose:
+      - 80
+    environment:
+      ADMIN_USERNAME: admin
+      ADMIN_EMAIL: admin@example.com
+      ADMIN_PASSWORD: admin
+      SITE_TITLE: multisite
+      SITE_URL: ${MULTISITE_HOST:-multisite.wordpress.test}
+      VIRTUAL_HOST: ${MULTISITE_HOST:-multisite.wordpress.test},test.${MULTISITE_HOST:-multisite.wordpress.test},translate.${MULTISITE_HOST:-multisite.wordpress.test}
+    volumes:
+      - "./plugins:/var/www/html/wp-content/plugins:delegated"
+      - "./wordpress:/var/www/html:delegated"
+      - "./config/multisitedomain-wordpress-config.php:/var/www/html/wp-config.php:delegated"
+      - "./config/multisite.htaccess:/var/www/html/.htaccess:delegated"
+      - "./data/xdebug:/var/xdebug:delegated"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
+    labels:
+      - com.yoast.plugin-development-docker.mainwpinstance
+
   # Standalone WordPress:
   standalone-database:
     container_name: "wordpress-standalone-database"
@@ -174,4 +215,5 @@ volumes:
   basic-database-data:
   woocommerce-database-data:
   multisite-database-data:
+  multisitedomain-database-data: 
   standalone-database-data:

--- a/make.sh
+++ b/make.sh
@@ -68,6 +68,8 @@ source ./config/config.sh
 change_hostfile ${BASIC_HOST:-basic.wordpress.test}
 change_hostfile ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
 change_hostfile ${MULTISITE_HOST:-multisite.wordpress.test}
+change_hostfile test.${MULTISITE_HOST:-multisite.wordpress.test}
+change_hostfile translate.${MULTISITE_HOST:-multisite.wordpress.test}
 change_hostfile ${STANDALONE_HOST:-standalone.wordpress.test}
 change_hostfile ${BASIC_DATABASE_HOST:-basic-database.wordpress.test}
 change_hostfile ${WOOCOMMERCE_DATABASE_HOST:-woocommerce-database.wordpress.test}

--- a/seeds/multisite-wordpress-seed.sh
+++ b/seeds/multisite-wordpress-seed.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
-wp core multisite-install --url=${SITE_URL} --title=${SITE_TITLE} --admin_user=${ADMIN_USERNAME} --admin_password=${ADMIN_PASSWORD} --admin_email=${ADMIN_EMAIL}
+wp core multisite-install --url=${SITE_URL} --title=${SITE_TITLE} --admin_user=${ADMIN_USERNAME} --admin_password=${ADMIN_PASSWORD} --admin_email=${ADMIN_EMAIL} --subdomains
 wp rewrite structure "%postname%/"
 wp rewrite flush --hard
 wp plugin install debug-bar --activate
 wp plugin install query-monitor --activate
 wp super-admin add admin
-wp site create --slug=site2
+wp site create --slug=test
+wp site create --slug=translate
 wp faker core content
-wp faker core content --url=${SITE_URL}/site2
+wp faker core content --url=test.${SITE_URL}
+wp faker core content --url=translate.${SITE_URL}

--- a/seeds/multisite-wordpress-seed.sh
+++ b/seeds/multisite-wordpress-seed.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
-wp core multisite-install --url=${SITE_URL} --title=${SITE_TITLE} --admin_user=${ADMIN_USERNAME} --admin_password=${ADMIN_PASSWORD} --admin_email=${ADMIN_EMAIL} --subdomains
+wp core multisite-install --url=${SITE_URL} --title=${SITE_TITLE} --admin_user=${ADMIN_USERNAME} --admin_password=${ADMIN_PASSWORD} --admin_email=${ADMIN_EMAIL}
 wp rewrite structure "%postname%/"
 wp rewrite flush --hard
 wp plugin install debug-bar --activate
 wp plugin install query-monitor --activate
 wp super-admin add admin
-wp site create --slug=test
-wp site create --slug=translate
+wp site create --slug=site2
 wp faker core content
-wp faker core content --url=test.${SITE_URL}
-wp faker core content --url=translate.${SITE_URL}
+wp faker core content --url=${SITE_URL}/site2

--- a/seeds/multisitedomain-wordpress-seed.sh
+++ b/seeds/multisitedomain-wordpress-seed.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+wp core multisite-install --url=${SITE_URL} --title=${SITE_TITLE} --admin_user=${ADMIN_USERNAME} --admin_password=${ADMIN_PASSWORD} --admin_email=${ADMIN_EMAIL} --subdomains
+wp rewrite structure "%postname%/"
+wp rewrite flush --hard
+wp plugin install debug-bar --activate
+wp plugin install query-monitor --activate
+wp super-admin add admin
+wp site create --slug=test
+wp site create --slug=translate
+wp faker core content
+wp faker core content --url=test.${SITE_URL}
+wp faker core content --url=translate.${SITE_URL}

--- a/start.sh
+++ b/start.sh
@@ -27,11 +27,13 @@ fi
 URL_basic_wordpress="http://${BASIC_HOST:-basic.wordpress.test}"
 URL_woocommerce_wordpress="http://${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}"
 URL_multisite_wordpress="http://${MULTISITE_HOST:-multisite.wordpress.test}"
+URL_multisitedomain_wordpress="http://${MULTISITE_HOST:-multisite.wordpress.test}"
 URL_standalone_wordpress="http://${STANDALONE_HOST:-standalone.wordpress.test}"
 
 PORT_basic_wordpress=1987
 PORT_woocommerce_wordpress=1988
 PORT_multisite_wordpress=1989
+PORT_multisitedomain_wordpress=1991
 PORT_standalone_wordpress=1990
 
 USER_ID=`id -u`


### PR DESCRIPTION
With this change you can now start a multisite WordPress installation using subdomains that has the following urls:

- test.multisite.wordpress.test
- translate.multisite.wordpress.test

Start the multisite by running the following command: 
./start multisitedomain-wordpress
