### PR TITLE
Fix nc port check

### DIFF
--- a/config/start_mac.sh
+++ b/config/start_mac.sh
@@ -10,7 +10,7 @@ function await_database_connections() {
             DB_PORT_VAR="DB_PORT_${CONTAINER//-/_}"
             DB_PORT=${!DB_PORT_VAR}
                         
-			until nc -z -v -w30 localhost ${DB_PORT} 2>&1 | grep "${DB_PORT}"; do
+			until nc -z -v -w30 localhost ${DB_PORT} 2>&1 | grep -E "${DB_PORT}.+(open|succeeded!)$"; do
 				echo "Waiting until database accepts connections at port $DB_PORT..."
 				sleep 2
 			done

--- a/config/start_mac.sh
+++ b/config/start_mac.sh
@@ -10,7 +10,7 @@ function await_database_connections() {
             DB_PORT_VAR="DB_PORT_${CONTAINER//-/_}"
             DB_PORT=${!DB_PORT_VAR}
                         
-			until nc -z -v -w30 localhost ${DB_PORT} 2>&1 | grep -E "${DB_PORT}.+open$"; do
+			until nc -z -v -w30 localhost ${DB_PORT} 2>&1 | grep "${DB_PORT}"; do
 				echo "Waiting until database accepts connections at port $DB_PORT..."
 				sleep 2
 			done


### PR DESCRIPTION
Netcat has different versions. One version shows another success message than the other. This caused the port check to fail.

Different messages:
`localhost [127.0.0.1] 1987 (tr-rsrb-p1) open`
`Connection to localhost port 1987 [tcp/tr-rsrb-p1] succeeded!`

The check only looked for the port number and `open`. Now it checks for `open` OR `succeeded!`.

Tested by @Xyfi and myself (different NC versions).