### PR TITLE
Fix Docker issues with 2.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "127.0.0.1:80:80"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - "./config/yoastnginx.conf:/etc/nginx/conf.d/yoastnginx.conf:delegated"
+      - "./config/yoastnginx.conf:/etc/nginx/conf.d/yoastnginx.conf"
   
   # Basic WordPress:
   basic-database:
@@ -25,7 +25,7 @@ services:
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
     volumes:
-      - "basic-database-data:/var/lib/mysql:delegated"
+      - "basic-database-data:/var/lib/mysql"
   basic-wordpress:
     container_name: "basic-wordpress"
     depends_on:
@@ -43,11 +43,11 @@ services:
       SITE_URL: ${BASIC_HOST:-basic.wordpress.test}
       VIRTUAL_HOST: ${BASIC_HOST:-basic.wordpress.test}
     volumes:
-      - "./plugins:/var/www/html/wp-content/plugins:delegated"
-      - "./config/basic-wordpress-config.php:/var/www/html/wp-config.php:delegated"
-      - "./wordpress:/var/www/html:delegated"
-      - "./xdebug:/var/xdebug:delegated"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
+      - "./plugins:/var/www/html/wp-content/plugins"
+      - "./config/basic-wordpress-config.php:/var/www/html/wp-config.php"
+      - "./wordpress:/var/www/html"
+      - "./xdebug:/var/xdebug"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -65,7 +65,7 @@ services:
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
     volumes:
-      - "woocommerce-database-data:/var/lib/mysql:delegated"
+      - "woocommerce-database-data:/var/lib/mysql"
   woocommerce-wordpress:
     container_name: "woocommerce-wordpress"
     depends_on:
@@ -83,11 +83,11 @@ services:
       SITE_URL: ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
       VIRTUAL_HOST: ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
     volumes:
-      - "./plugins:/var/www/html/wp-content/plugins:delegated"
-      - "./wordpress:/var/www/html:delegated"
-      - "./config/woocommerce-wordpress-config.php:/var/www/html/wp-config.php:delegated"
-      - "./data/xdebug:/var/xdebug:delegated"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
+      - "./plugins:/var/www/html/wp-content/plugins"
+      - "./config/woocommerce-wordpress-config.php:/var/www/html/wp-config.php"
+      - "./wordpress:/var/www/html"
+      - "./data/xdebug:/var/xdebug"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -105,7 +105,7 @@ services:
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
     volumes:
-      - "multisite-database-data:/var/lib/mysql:delegated"
+      - "multisite-database-data:/var/lib/mysql"
   multisite-wordpress:
     container_name: "multisite-wordpress"
     depends_on:
@@ -123,12 +123,12 @@ services:
       SITE_URL: ${MULTISITE_HOST:-multisite.wordpress.test}
       VIRTUAL_HOST: ${MULTISITE_HOST:-multisite.wordpress.test},test.${MULTISITE_HOST:-multisite.wordpress.test},translate.${MULTISITE_HOST:-multisite.wordpress.test}
     volumes:
-      - "./plugins:/var/www/html/wp-content/plugins:delegated"
-      - "./wordpress:/var/www/html:delegated"
-      - "./config/multisite-wordpress-config.php:/var/www/html/wp-config.php:delegated"
-      - "./config/multisite.htaccess:/var/www/html/.htaccess:delegated"
-      - "./data/xdebug:/var/xdebug:delegated"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
+      - "./plugins:/var/www/html/wp-content/plugins"
+      - "./config/multisite-wordpress-config.php:/var/www/html/wp-config.php"
+      - "./config/multisite.htaccess:/var/www/html/.htaccess"
+      - "./wordpress:/var/www/html"
+      - "./data/xdebug:/var/xdebug"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -146,7 +146,7 @@ services:
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
     volumes:
-      - "multisitedomain-database-data:/var/lib/mysql:delegated"
+      - "multisitedomain-database-data:/var/lib/mysql"
   multisitedomain-wordpress:
     container_name: "multisitedomain-wordpress"
     depends_on:
@@ -164,12 +164,12 @@ services:
       SITE_URL: ${MULTISITE_HOST:-multisite.wordpress.test}
       VIRTUAL_HOST: ${MULTISITE_HOST:-multisite.wordpress.test},test.${MULTISITE_HOST:-multisite.wordpress.test},translate.${MULTISITE_HOST:-multisite.wordpress.test}
     volumes:
-      - "./plugins:/var/www/html/wp-content/plugins:delegated"
-      - "./wordpress:/var/www/html:delegated"
-      - "./config/multisitedomain-wordpress-config.php:/var/www/html/wp-config.php:delegated"
-      - "./config/multisite.htaccess:/var/www/html/.htaccess:delegated"
-      - "./data/xdebug:/var/xdebug:delegated"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
+      - "./plugins:/var/www/html/wp-content/plugins"
+      - "./config/multisitedomain-wordpress-config.php:/var/www/html/wp-config.php"
+      - "./config/multisite.htaccess:/var/www/html/.htaccess"
+      - "./wordpress:/var/www/html"
+      - "./data/xdebug:/var/xdebug"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -187,7 +187,7 @@ services:
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
     volumes:
-      - "standalone-database-data:/var/lib/mysql:delegated"
+      - "standalone-database-data:/var/lib/mysql"
   standalone-wordpress:
     container_name: "standalone-wordpress"
     depends_on:
@@ -205,11 +205,11 @@ services:
       SITE_URL: ${STANDALONE_HOST:-standalone.wordpress.test}
       VIRTUAL_HOST: ${STANDALONE_HOST:-standalone.wordpress.test}
     volumes:
-      - "./sa-plugins:/var/www/html/wp-content/plugins:delegated"
-      - "./config/standalone-wordpress-config.php:/var/www/html/wp-config.php:delegated"
-      - "./wordpress:/var/www/html:delegated"
-      - "./xdebug:/var/xdebug:delegated"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:delegated"
+      - "./sa-plugins:/var/www/html/wp-content/plugins"
+      - "./config/standalone-wordpress-config.php:/var/www/html/wp-config.php"
+      - "./wordpress:/var/www/html"
+      - "./xdebug:/var/xdebug"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
 
 volumes:
   basic-database-data:


### PR DESCRIPTION
I've removed all delegated caching options and moved some mounting orders around. I was unable to reproduce the original issues anymore, though there may be some sluggishness coming back since there is no more caching. However, Docker may have fixed this in one of their recent releases.