### PR TITLE
Several changes to mounting and caching

### DIFF
--- a/config/start_mac.sh
+++ b/config/start_mac.sh
@@ -33,11 +33,11 @@ function install_wordpress() {
             echo "WordPress has NOT been configured.".			
 			echo "Installing WordPress in container $CONTAINER..."
 
-            docker exec -ti "$CONTAINER" /bin/bash -c 'mkdir -p /var/www/.wp-cli/packages; chown -R www-data: /var/www/.wp-cli;'
-            docker exec --user "$USER_ID" -ti "$CONTAINER" /bin/bash -c 'php -d memory_limit=512M "$(which wp)" package install git@github.com:Yoast/wp-cli-faker.git'
-            docker cp ./seeds "$CONTAINER":/seeds
+			docker exec -ti "$CONTAINER" /bin/bash -c 'ln -sf /tmp/wp-config.php /var/www/html/wp-config.php'
 
-			chown u+w wp-content
+            docker exec -ti "$CONTAINER" /bin/bash -c 'mkdir -p /var/www/.wp-cli/packages; chown -R www-data: /var/www/.wp-cli;'
+            docker exec --user "$USER_ID" -ti "$CONTAINER" /bin/bash -c 'php -d memory_limit=512M "$(which wp)" package install git@github.com:yoast/wp-cli-faker.git'
+            docker cp ./seeds "$CONTAINER":/seeds
 
             docker exec --user "$USER_ID" -ti "$CONTAINER" /seeds/"$CONTAINER"-seed.sh
         fi

--- a/config/start_win.sh
+++ b/config/start_win.sh
@@ -31,9 +31,11 @@ function install_wordpress() {
             echo "WordPress has NOT been configured.".
 			echo "Installing WordPress in container $CONTAINER..."
 
+            docker exec -ti "$CONTAINER" //bin/bash -c 'ln -sf /tmp/wp-config.php /var/www/html/wp-config.php'
+
             docker exec -i "$CONTAINER" //bin/bash -c 'mkdir -p /var/www/.wp-cli/packages; chown -R www-data: /var/www/.wp-cli;'
             docker exec -i "$CONTAINER" //bin/bash -c 'chown www-data: /var/www/html/wp-content'
-            docker exec --user "$USER_ID" -i "$CONTAINER" //bin/bash -c 'php -d memory_limit=512M "$(which wp)" package install git@github.com:Yoast/wp-cli-faker.git'
+            docker exec --user "$USER_ID" -i "$CONTAINER" //bin/bash -c 'php -d memory_limit=512M "$(which wp)" package install git@github.com:yoast/wp-cli-faker.git'
             
 			docker cp ./seeds "$CONTAINER":/seeds						       		
             docker exec --user "$USER_ID" -i "$CONTAINER" //seeds/"$CONTAINER"-seed.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,11 +43,11 @@ services:
       SITE_URL: ${BASIC_HOST:-basic.wordpress.test}
       VIRTUAL_HOST: ${BASIC_HOST:-basic.wordpress.test}
     volumes:
-      - "./plugins:/var/www/html/wp-content/plugins"
-      - "./config/basic-wordpress-config.php:/var/www/html/wp-config.php"
-      - "./wordpress:/var/www/html"
-      - "./xdebug:/var/xdebug"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+      - "./wordpress:/var/www/html:cached"
+      - "./plugins:/var/www/html/wp-content/plugins:cached"
+      - "./config/basic-wordpress-config.php:/tmp/wp-config.php:ro"
+      - "./xdebug:/var/xdebug:cached"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -83,11 +83,11 @@ services:
       SITE_URL: ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
       VIRTUAL_HOST: ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
     volumes:
-      - "./plugins:/var/www/html/wp-content/plugins"
-      - "./config/woocommerce-wordpress-config.php:/var/www/html/wp-config.php"
-      - "./wordpress:/var/www/html"
-      - "./data/xdebug:/var/xdebug"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+      - "./wordpress:/var/www/html:cached"
+      - "./plugins:/var/www/html/wp-content/plugins:cached"
+      - "./config/woocommerce-wordpress-config.php:/tmp/wp-config.php:ro"
+      - "./data/xdebug:/var/xdebug:cached"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -123,12 +123,12 @@ services:
       SITE_URL: ${MULTISITE_HOST:-multisite.wordpress.test}
       VIRTUAL_HOST: ${MULTISITE_HOST:-multisite.wordpress.test},test.${MULTISITE_HOST:-multisite.wordpress.test},translate.${MULTISITE_HOST:-multisite.wordpress.test}
     volumes:
-      - "./plugins:/var/www/html/wp-content/plugins"
-      - "./config/multisite-wordpress-config.php:/var/www/html/wp-config.php"
-      - "./config/multisite.htaccess:/var/www/html/.htaccess"
-      - "./wordpress:/var/www/html"
-      - "./data/xdebug:/var/xdebug"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+      - "./wordpress:/var/www/html:cached"
+      - "./plugins:/var/www/html/wp-content/plugins:cached"
+      - "./config/multisite-wordpress-config.php:/tmp/wp-config.php:ro"
+      - "./config/multisite.htaccess:/var/www/html/.htaccess:cached"
+      - "./data/xdebug:/var/xdebug:cached"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -164,12 +164,12 @@ services:
       SITE_URL: ${MULTISITE_HOST:-multisite.wordpress.test}
       VIRTUAL_HOST: ${MULTISITE_HOST:-multisite.wordpress.test},test.${MULTISITE_HOST:-multisite.wordpress.test},translate.${MULTISITE_HOST:-multisite.wordpress.test}
     volumes:
-      - "./plugins:/var/www/html/wp-content/plugins"
-      - "./config/multisitedomain-wordpress-config.php:/var/www/html/wp-config.php"
-      - "./config/multisite.htaccess:/var/www/html/.htaccess"
-      - "./wordpress:/var/www/html"
-      - "./data/xdebug:/var/xdebug"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+      - "./wordpress:/var/www/html:cached"
+      - "./plugins:/var/www/html/wp-content/plugins:cached"
+      - "./config/multisitedomain-wordpress-config.php:/tmp/wp-config.php:ro"
+      - "./config/multisite.htaccess:/var/www/html/.htaccess:cached"
+      - "./data/xdebug:/var/xdebug:cached"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
 
@@ -205,11 +205,11 @@ services:
       SITE_URL: ${STANDALONE_HOST:-standalone.wordpress.test}
       VIRTUAL_HOST: ${STANDALONE_HOST:-standalone.wordpress.test}
     volumes:
-      - "./sa-plugins:/var/www/html/wp-content/plugins"
-      - "./config/standalone-wordpress-config.php:/var/www/html/wp-config.php"
-      - "./wordpress:/var/www/html"
-      - "./xdebug:/var/xdebug"
-      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini"
+      - "./wordpress:/var/www/html:cached"
+      - "./sa-plugins:/var/www/html/wp-content/plugins:cached"
+      - "./config/standalone-wordpress-config.php:/tmp/wp-config.php:ro"
+      - "./xdebug:/var/xdebug:cached"
+      - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
 
 volumes:
   basic-database-data:


### PR DESCRIPTION
Fixes bugs where 
- running multiple containers would cause only one container to work and the rest to fail
- changing files would cause wp-config.php to unmount and crash the instance
- a warning was shown about an incorrect composer repo name (Yoast -> yoast)

Improves:
- mounting order
- caching

@noud-github and me have decided to mount `wp-config.php` to the `/tmp` folder of a container and symlink it to its intended location in the `/var/www/html` folder. Tise prevents problems with inception-mounting. This also retains the ability to edit your wp-config file in the /config folder on your host machine so the changes go through to the Docker instance.