### PR TITLE
Add Xdebug 3.0 configuration

### DIFF
--- a/config/php.ini.default
+++ b/config/php.ini.default
@@ -1,3 +1,4 @@
+; XDEBUG 2.0 configuration:
 xdebug.remote_enable = On
 xdebug.remote_host   = host.docker.internal
 xdebug.remote_port   = 9000
@@ -12,6 +13,17 @@ xdebug.trace_output_name    = trace.%R.%p
 
 xdebug.remote_log = /var/xdebug/xdebug.log
 
+; XDEBUG 3.0 configuration:
+xdebug.mode = debug ; debug/trace/profile
+xdebug.client_host   = host.docker.internal
+xdebug.client_port   = 9000
+
+xdebug.start_with_request = trigger ;trigger/yes
+
+xdebug.output_dir     = /var/xdebug
+xdebug.log = /var/xdebug/xdebug.log
+
+; Default PHP.INI configuration:
 error_reporting        = E_ALL
 display_startup_errors = On
 display_errors         = On


### PR DESCRIPTION
XDebug released version 3.0 which overhauled its configuration usage and naming conventions. I've rewritten the `php.ini.default` to accommodate both xdebug 2.0 as well as 3.0, as not everyone will receive XDebug 3.0 immediately. All configurations have been retrieved from this guide: https://xdebug.org/docs/upgrade_guide

To use this, please run `bash clean.sh --all` to purge all configuration files. 
_Warning: this will wipe all your docker test sites and custom configuration files, if you have any. Make sure to backup any custom configurations in `php.ini`, `config.sh` and `Dockerfile`._
Now run `bash make.sh` and then start your containers as you normally would.