### PR TITLE
Install default-mysql-client so wp-cli db functions can be used

### DIFF
--- a/containers/wordpress/Dockerfile.template
+++ b/containers/wordpress/Dockerfile.template
@@ -3,6 +3,9 @@ FROM wordpress:latest
 RUN pecl install xdebug && docker-php-ext-enable xdebug
 RUN docker-php-ext-install pdo_mysql
 
+RUN apt-get update
+RUN apt-get -y install default-mysql-client
+
 RUN curl -sO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
     && chmod +x wp-cli.phar \
     && mv wp-cli.phar /usr/local/bin/wp

--- a/containers/wordpress/Dockerfile.template
+++ b/containers/wordpress/Dockerfile.template
@@ -3,8 +3,8 @@ FROM wordpress:latest
 RUN pecl install xdebug && docker-php-ext-enable xdebug
 RUN docker-php-ext-install pdo_mysql
 
-RUN apt-get update
-RUN apt-get -y install default-mysql-client
+RUN apt-get update \
+    && apt-get -y install default-mysql-client
 
 RUN curl -sO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
     && chmod +x wp-cli.phar \


### PR DESCRIPTION
Before this PR, if you try to run `wp db` commands (i.e. `wp db reset`) you will get an error:
`Error: Failed to get current SQL modes. Reason: /usr/bin/env: 'mysql': No such file or directory`

After doing some research I came across this issue: https://github.com/wp-cli/ideas/issues/52. Seeing that this  issue is 4 years old I don't see this fixed very soon and the solution is to install the  `default-mysql-client`. 

### Test instructions

Delete `containers/wordpress/Dockerfile` and `containers/wordpress/Dockerfile-e`.
Run `./clean`
Run `./make`
Run `./start`

Check that the wordpress installation is working as expected. (Login with `admin` `admin`.)

Now run `docker exec -it --user www-data basic-wordpress wp db reset`.

Wordpress should now behave like a fresh installation. If you go to `wp-admin` you'll be prompted to configure your site.