### PR TITLE
Install less in wordpress docker container in order for wp-cli help to work

### DIFF
--- a/containers/wordpress/Dockerfile.template
+++ b/containers/wordpress/Dockerfile.template
@@ -4,7 +4,7 @@ RUN pecl install xdebug && docker-php-ext-enable xdebug
 RUN docker-php-ext-install pdo_mysql
 
 RUN apt-get update \
-    && apt-get -y install default-mysql-client
+    && apt-get -y install default-mysql-client less
 
 RUN curl -sO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
     && chmod +x wp-cli.phar \


### PR DESCRIPTION
When running `docker exec -it --user=www-data wordpress-basic wp help`, I got the following error: `less: not found`. Apparently wp-cli requires less in order for its help function to work.

Test instructions:

- Delete `containers/wordpress/Dockerfile`
- Remove your wordpress-basic image. 
  - Run `docker image ls` and copy the image id of `plugin-development-docker_basic-wordpress`
  - Run `docker image rm {image-id}`
- Run `./start`
- In a different terminal run `docker exec -it --user=www-data wordpress-basic wp help` and make sure you get the wp-cli help instead of `less: not found`.