### PR TITLE
Change docker PS command to not check for ancestor as label is enough

### DIFF
--- a/wp.sh
+++ b/wp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Get all the running containers and store the amount
-running_containers=$(docker ps --filter "ancestor=wordpress" --filter "label="com.yoast.plugin-development-docker.mainwpinstance"" --format "{{.Names}}")
+running_containers=$(docker ps --filter "label="com.yoast.plugin-development-docker.mainwpinstance"" --format "{{.Names}}")
 count_containers=$(echo "$running_containers" | wc -l)
 
 # Check if the first argument is a docker container...


### PR DESCRIPTION
This change fixes an issue where the `docker ps` command in the WP-CLI wrapper would not return any containers. Sometimes containers are not run with `wordpress` as an ancestor. As the other filter checks for the correct labels, and those are always the same, I opted to remove the `ancestor` filter entirely. 

This fixes the error:
```
❯ ./wp.sh basic-wordpress core version
Error: No such container: wp
```
As this error happens when no containers are in the `$CONTAINER` variable and thus docker assumes `wp` to be the container name.