### PR TITLE
Random table prefix done differently.

### DIFF
--- a/config/basic-wordpress-config.php
+++ b/config/basic-wordpress-config.php
@@ -18,6 +18,21 @@
  * @package WordPress
  */
 
+if (!function_exists('getenv_docker')) {
+	// https://github.com/docker-library/wordpress/issues/588 (WP-CLI will load this file 2x)
+	function getenv_docker($env, $default) {
+		if ($fileEnv = getenv($env . '_FILE')) {
+			return rtrim(file_get_contents($fileEnv), "\r\n");
+		}
+		else if (($val = getenv($env)) !== false) {
+			return $val;
+		}
+		else {
+			return $default;
+		}
+	}
+}
+
 // ** MySQL settings - You can get this info from your web host ** //
 /** The name of the database for WordPress */
 define( 'DB_NAME', 'wordpress');
@@ -65,7 +80,7 @@ define( 'FS_METHOD', 'direct' );
  * You can have multiple installations in one database if you give each
  * a unique prefix. Only numbers, letters, and underscores please!
  */
-$table_prefix = 'wp_';
+$table_prefix = getenv_docker('WORDPRESS_TABLE_PREFIX', 'wp_');
 
 /**
  * For developers: WordPress debugging mode.

--- a/config/start_mac.sh
+++ b/config/start_mac.sh
@@ -55,11 +55,7 @@ function install_wordpress() {
             echo "WordPress has NOT been configured.".		
 			echo "Installing WordPress in container $CONTAINER..."
 
-			docker exec -ti "$CONTAINER" /bin/bash -c 'cp /tmp/wp-config.php /var/www/html/wp-config.php; chown www-data: /var/www/html/wp-config.php; chmod +w /var/www/html/wp-config.php'
-			# Change the wordpress table_prefix to 5 random characters
-			RANDOM_DBTABLE_PREFIX=$(LC_ALL=C tr -dc a-z < /dev/urandom | head -c 5 | xargs)
-			docker exec -ti "$CONTAINER" /bin/bash -c "sed -i \"s#table_prefix = 'wp_'#table_prefix = '"$RANDOM_DBTABLE_PREFIX"_'#\" /var/www/html/wp-config.php"
-
+			docker exec -ti "$CONTAINER" /bin/bash -c 'ln -sf /tmp/wp-config.php /var/www/html/wp-config.php'
             docker exec -ti "$CONTAINER" /bin/bash -c 'mkdir -p /var/www/.wp-cli/packages; chown -R www-data: /var/www/.wp-cli;'
             docker exec --user "$USER_ID" -ti "$CONTAINER" /bin/bash -c 'php -d memory_limit=512M "$(which wp)" package install git@github.com:yoast/wp-cli-faker.git'
             docker cp ./seeds "$CONTAINER":/seeds

--- a/config/start_win.sh
+++ b/config/start_win.sh
@@ -43,7 +43,7 @@ function install_wordpress() {
 		echo "OK"
 
 		#-Xallow-non-tty tells winpty to route output of non-tty ming64 bash to stdout so we can read it
-        docker exec "$CONTAINER" bash -c 'cp /tmp/wp-config.php /var/www/html/wp-config.php; chown www-data: /var/www/html/wp-config.php; chmod +w /var/www/html/wp-config.php'
+        docker exec -ti "$CONTAINER" /bin/bash -c 'ln -sf /tmp/wp-config.php /var/www/html/wp-config.php'
         docker exec "$CONTAINER" bash -c 'mkdir -p /var/www/.wp-cli/packages; chown -R www-data: /var/www/.wp-cli;'
 		IS_INSTALLED=$(docker exec "$CONTAINER" wp core is-installed --allow-root --path='/var/www/html' 2>&1)
 
@@ -51,10 +51,7 @@ function install_wordpress() {
             echo "WordPress has NOT been configured."
             sleep 20
 			echo "Installing WordPress in container $CONTAINER..."
-            # Change the wordpress table_prefix to 5 random characters
-            RANDOM_DBTABLE_PREFIX=$(LC_CTYPE=C tr -dc a-z < /dev/urandom | head -c 5)
-			docker exec "$CONTAINER" bash -c "sed -i \"s#table_prefix = 'wp_'#table_prefix = '"$RANDOM_DBTABLE_PREFIX"_'#\" /var/www/html/wp-config.php"
-            
+
             docker exec "$CONTAINER" bash -c 'chown www-data: /var/www/html/wp-content'
             docker exec "$CONTAINER" bash -c 'chown www-data: /var/www/html/wp-includes'
             docker exec --user "$USER_ID" "$CONTAINER" bash -c 'php -d memory_limit=512M "$(which wp)" package install git@github.com:yoast/wp-cli-faker.git'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       SITE_TITLE: Basic
       SITE_URL: ${BASIC_HOST:-basic.wordpress.test}
       VIRTUAL_HOST: ${BASIC_HOST:-basic.wordpress.test}
+      WORDPRESS_TABLE_PREFIX: ${WORDPRESS_TABLE_PREFIX}
     volumes:
       - "./wordpress:/var/www/html"
       - "./plugins:/var/www/html/wp-content/plugins:cached"

--- a/start.sh
+++ b/start.sh
@@ -30,6 +30,9 @@ DB_PORT_multisite_wordpress=1989
 DB_PORT_standalone_wordpress=1990
 DB_PORT_multisitedomain_wordpress=1991
 
+#set environment variable for the Wordpress DB Table Prefix
+export WORDPRESS_TABLE_PREFIX="$(LC_ALL=C tr -dc a-z < /dev/urandom | head -c 5 | xargs)_"
+
 USER_ID=`id -u`
 GROUP_ID=`id -g`
 STOPPING=false


### PR DESCRIPTION
/var/www/html/wp-config.php is a symlink again. Generating the random table prefix is done differently.