### PR TITLE
Fix WordPress table prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ xdebug/*
 !xdebug/.gitkeep
 config/php.ini
 config/config.sh
+config/wp-table-prefix
 plugins/*
 !plugins/.gitkeep
 sa-plugins/*

--- a/clean.sh
+++ b/clean.sh
@@ -9,6 +9,9 @@ docker-compose rm -fv
 rm -rf wordpress
 git checkout -- wordpress/.gitkeep
 
+# Remove our saved WordPress table prefix.
+rm -f ./config/wp-table-prefix
+
 case $1 in
     -a|--all)
         echo "Option '--all' defined. Removing non-default config files."

--- a/make.sh
+++ b/make.sh
@@ -5,6 +5,14 @@
 
 source platform.sh
 
+# Set environment variable for the Wordpress DB Table Prefix.
+# Save this in a file so it is not random every boot (clean.sh removes this file).
+if [ ! -f ./config/wp-table-prefix ]; then
+  WORDPRESS_TABLE_PREFIX="$(LC_ALL=C tr -dc a-z < /dev/urandom | head -c 5 | xargs)_"
+  echo $WORDPRESS_TABLE_PREFIX > ./config/wp-table-prefix
+  echo "WP table prefix: $WORDPRESS_TABLE_PREFIX"
+fi
+
 function prepare_files() {
 	# Remove corrupt php.ini folder, if existing.
 	[[ -d './config/php.ini' ]] && rm -rf './config/php.ini'

--- a/start.sh
+++ b/start.sh
@@ -32,8 +32,9 @@ DB_PORT_standalone_wordpress=1990
 DB_PORT_multisitedomain_wordpress=1991
 DB_PORT_nightly_wordpress=1992
 
-#set environment variable for the Wordpress DB Table Prefix
-export WORDPRESS_TABLE_PREFIX="$(LC_ALL=C tr -dc a-z < /dev/urandom | head -c 5 | xargs)_"
+# Get environment variable for the Wordpress DB Table Prefix
+export WORDPRESS_TABLE_PREFIX="$(cat ./config/wp-table-prefix)"
+echo "WP table prefix: $WORDPRESS_TABLE_PREFIX"
 
 USER_ID=`id -u`
 GROUP_ID=`id -g`


### PR DESCRIPTION
Major props Arnoud 😄 

Changelog:
* Fixes the WordPress table prefix, by generating it only once.

Details:
* `make.sh` creates and saves the prefix in `./config/wp-table-prefix`
* `clean.sh` removes `./config/wp-table-prefix`
* `start.sh` reads the value
