### PR TITLE
Switch to Rancher Desktop for macOS

### DIFF
--- a/Rancher-mac.md
+++ b/Rancher-mac.md
@@ -1,0 +1,32 @@
+# Switching to Rancher Desktop on MacOS
+
+## Removing old entries
+
+- Uninstall Docker Desktop
+- Remove Existing Symlinks:
+
+```bash
+cd /usr/local/bin
+rm docker docker-compose-v1 docker-credential-desktop docker-credential-ecr-login docker-credential-osxkeychain com.docker.cli
+cd ~
+```
+
+- In ~/.docker/config.json rename **credsStore** to **credStore**
+
+## Installing Rancher Desktop
+
+- Download [Rancher Desktop](https://github.com/rancher-sandbox/rancher-desktop/releases)
+- In the `General` tab disable: `Allow Collection of Anonymous statistics`
+- In the `Kubernetes` tab change container runtime to: `dockerd (Moby)` 
+- In the `Kubernetes` tab change memory and CPU to half of your system resources.
+- In the `Supporting Utilities` tab enable all symbolic links
+
+## Installing docker-compose
+
+- Install docker-compose:
+
+```bash
+brew install docker-compose
+```
+
+You can now use plugin-development-docker as you would normally would :)

--- a/Rancher-mac.md
+++ b/Rancher-mac.md
@@ -15,7 +15,12 @@ cd ~
 
 ## Installing Rancher Desktop
 
-- Download [Rancher Desktop](https://github.com/rancher-sandbox/rancher-desktop/releases)
+- Download Rancher Desktop
+  - Rancher Desktop is still in beta at the moment of writing, to make sure that you are on the same version please use the following links to download:
+    - [macOS Intel (Most Common)](https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.0.0-beta.1/Rancher.Desktop-1.0.0-beta.1.x86_64.dmg)
+    - [macOS M1](https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.0.0-beta.1/Rancher.Desktop-1.0.0-beta.1.aarch64.dmg)
+    - [Windows](https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.0.0-beta.1/Rancher.Desktop.Setup.1.0.0-beta.1.exe)
+
 - In the `General` tab disable: `Allow Collection of Anonymous statistics`
 - In the `Kubernetes` tab change container runtime to: `dockerd (Moby)` 
 - In the `Kubernetes` tab change memory and CPU to half of your system resources.

--- a/Rancher-mac.md
+++ b/Rancher-mac.md
@@ -31,3 +31,15 @@ brew install docker-compose
 ```
 
 You can now use plugin-development-docker as you would normally would :)
+
+## Troubleshooting
+
+### Rancher not starting
+
+- Rancher Desktop does not support macOS <10.15 please update to the latest macOS
+
+### Stale NFS mount
+
+macOs TCC polcies do not allow nfs mounting in the document folder.
+
+- Move the repository files to ~/Projects/plugin-development-docker

--- a/Rancher-mac.md
+++ b/Rancher-mac.md
@@ -7,7 +7,7 @@
 
 ```bash
 cd /usr/local/bin
-rm docker docker-compose-v1 docker-credential-desktop docker-credential-ecr-login docker-credential-osxkeychain com.docker.cli
+rm docker docker-compose docker-compose-v1 docker-credential-desktop docker-credential-ecr-login docker-credential-osxkeychain com.docker.cli
 cd ~
 ```
 

--- a/Rancher-mac.md
+++ b/Rancher-mac.md
@@ -7,7 +7,7 @@
 
 ```bash
 cd /usr/local/bin
-rm docker docker-compose docker-compose-v1 docker-credential-desktop docker-credential-ecr-login docker-credential-osxkeychain com.docker.cli
+rm docker kubectl docker-compose docker-compose-v1 docker-credential-desktop docker-credential-ecr-login docker-credential-osxkeychain com.docker.cli
 cd ~
 ```
 

--- a/Rancher-mac.md
+++ b/Rancher-mac.md
@@ -15,11 +15,7 @@ cd ~
 
 ## Installing Rancher Desktop
 
-- Download Rancher Desktop
-  - Rancher Desktop is still in beta at the moment of writing, to make sure that you are on the same version please use the following links to download:
-    - [macOS Intel (Most Common)](https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.0.0-beta.1/Rancher.Desktop-1.0.0-beta.1.x86_64.dmg)
-    - [macOS M1](https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.0.0-beta.1/Rancher.Desktop-1.0.0-beta.1.aarch64.dmg)
-    - [Windows](https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.0.0-beta.1/Rancher.Desktop.Setup.1.0.0-beta.1.exe)
+- Download [Rancher Desktop](https://rancherdesktop.io/)
 
 - In the `General` tab disable: `Allow Collection of Anonymous statistics`
 - In the `Kubernetes` tab change container runtime to: `dockerd (Moby)` 

--- a/config/make_mac.sh
+++ b/config/make_mac.sh
@@ -7,6 +7,10 @@
 source config/config.sh
 source config/make_functions.sh
 
+# Current Workaround to disable Kubernetes in Rancher Desktop
+kubectl config use-context rancher-desktop
+kubectl delete node lima-rancher-desktop
+
 # Set path to hostfile
 hostfile=/etc/hosts
 

--- a/config/make_mac.sh
+++ b/config/make_mac.sh
@@ -7,10 +7,6 @@
 source config/config.sh
 source config/make_functions.sh
 
-# Current Workaround to disable Kubernetes in Rancher Desktop
-kubectl config use-context rancher-desktop
-kubectl delete node lima-rancher-desktop
-
 # Set path to hostfile
 hostfile=/etc/hosts
 

--- a/config/make_mac.sh
+++ b/config/make_mac.sh
@@ -38,6 +38,30 @@ function kill_port_80_usage () {
 }
 
 #######################################
+# Function set up nsf for usage #/System/Volumes/Data -alldirs -mapall=501:20 localhost
+# Globals:
+#   None
+# Arguments:
+#   None
+# Outputs:
+#   None
+#######################################
+function setup_NFS(){
+    if [ -z "$(sudo cat /etc/exports | grep '/System/Volumes/Data ')" ]; then
+        echo update exports
+        echo "/System/Volumes/Data -alldirs -mapall=$UID:20 localhost" | sudo tee -a /etc/exports
+        sudo nfsd restart
+    fi
+    if [ -z "$(sudo cat /etc/nfs.conf | grep -e '^nfs.server.mount.require_resv_port = 0$')" ]; then
+        echo update exports
+        echo "nfs.server.mount.require_resv_port = 0" | sudo tee -a /etc/nfs.conf
+        sudo nfsd restart
+    fi
+
+}
+
+
+#######################################
 # Function that groups make tasks
 # Globals:
 #   None
@@ -47,6 +71,7 @@ function kill_port_80_usage () {
 #   None
 #######################################
 function platform_make() {	
-	platform_independent_make $hostfile
+	setup_NFS
+    platform_independent_make $hostfile
 	kill_port_80_usage
 }

--- a/config/start_mac.sh
+++ b/config/start_mac.sh
@@ -45,14 +45,16 @@ function install_wordpress() {
         echo -n "Waiting for WordPress to start in container $CONTAINER..."
 
 		docker exec -ti "$CONTAINER" /bin/bash -c 'until [[ -f .htaccess ]]; do echo -n "."; sleep 1; done'
-		docker exec -ti "$CONTAINER" /bin/bash -c 'wp --allow-root core is-installed 2>/dev/null'
+		docker exec -ti "$CONTAINER" /bin/bash -c 'until [[ -f wp-config.php ]]; do echo -n "."; sleep 1; done'
 		
-		# $? is the exit code of the previous command.
+		docker exec -ti "$CONTAINER" /bin/bash -c 'wp --allow-root core is-installed 2>/dev/null'
+	    # $? is the exit code of the previous command.
         # We check if WP is installed, if it is not, it returns with exit code 1
         IS_INSTALLED=$?
 
         if [[ $IS_INSTALLED == 1 ]]; then
-            echo "WordPress has NOT been configured.".		
+            docker exec -ti "$CONTAINER" /bin/bash -c 'mkdir -p /var/www/.composer/cache/vcs'
+			echo "WordPress has NOT been configured.".		
 			echo "Installing WordPress in container $CONTAINER..."
 
 			docker exec -ti "$CONTAINER" /bin/bash -c 'ln -sf /tmp/wp-config.php /var/www/html/wp-config.php'

--- a/config/start_mac.sh
+++ b/config/start_mac.sh
@@ -138,3 +138,24 @@ function platform_tasks() {
 		synchronize_clocks
 	fi
 }
+
+#######################################
+# Check if Kubernetes is running
+# Globals:
+#   None
+# Arguments:
+#   None
+# Outputs:
+#   None
+#######################################
+function check_lima_node() {
+	# Current Workaround to disable Kubernetes in Rancher Desktop
+	kubectl config use-context rancher-desktop
+	NODES=$(kubectl get nodes | grep -o "lima-rancher-desktop")
+	if [[ "$NODES" == 'lima-rancher-desktop' ]]; then
+		echo "Lima node is running, shutting it down..."
+		kubectl delete node lima-rancher-desktop
+	else
+		echo "Lima node is not running, continuing..."
+	fi
+}

--- a/config/start_mac.sh
+++ b/config/start_mac.sh
@@ -151,7 +151,7 @@ function platform_tasks() {
 function check_lima_node() {
 	# Current Workaround to disable Kubernetes in Rancher Desktop
 	kubectl config use-context rancher-desktop
-	NODES=$(kubectl get nodes | grep -o "lima-rancher-desktop")
+	NODES=$(kubectl get nodes | grep -o "lima-rancher-desktop" || true)
 	if [[ "$NODES" == 'lima-rancher-desktop' ]]; then
 		echo "Lima node is running, shutting it down..."
 		kubectl delete node lima-rancher-desktop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
   mailhog:
     container_name: "mailhog-wordpress"
     image: mailhog/mailhog
-    logging:
-      driver: 'none'  # disable saving logs to prevent bloat
+    # logging:
+    #   driver: none  # disable saving logs to prevent bloat
     ports:
       - 127.0.0.1:8025:8025 # web ui
   
@@ -61,6 +61,8 @@ services:
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
+    extra_hosts:
+      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
   # WooCommerce WordPress:
   woocommerce-database:
@@ -102,6 +104,8 @@ services:
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
+    extra_hosts:
+      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
   # Multisite WordPress:
   multisite-database:
@@ -144,6 +148,8 @@ services:
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
+    extra_hosts:
+      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
   # Multisite WordPress using Subdomains:
   multisitedomain-database:
@@ -186,6 +192,8 @@ services:
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
+    extra_hosts:
+      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
   # Standalone WordPress:
   standalone-database:
@@ -225,6 +233,8 @@ services:
       - "./config/standalone-wordpress-config.php:/tmp/wp-config.php:ro"
       - "./xdebug:/var/xdebug:cached"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
+    extra_hosts:
+      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
 # Nightly WordPress:
   nightly-database:
@@ -266,6 +276,8 @@ services:
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
+    extra_hosts:
+      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
 volumes:
   basic-database-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,10 +297,10 @@ volumes:
     driver_opts:
       type: nfs
       o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
-      device: ":${PWD}/wordpress"
+      device: ":${PWD}/plugins"
   nfsmount_xdebug:
     driver: local
     driver_opts:
       type: nfs
       o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
-      device: ":${PWD}/wordpress"
+      device: ":${PWD}/xdebug"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     #   driver: none  # disable saving logs to prevent bloat
     ports:
       - 127.0.0.1:8025:8025 # web ui
-  
+
   # Basic WordPress:
   basic-database:
     container_name: "wordpress-basic-database"
@@ -54,10 +54,10 @@ services:
       VIRTUAL_HOST: ${BASIC_HOST:-basic.wordpress.test}
       WORDPRESS_TABLE_PREFIX: ${WORDPRESS_TABLE_PREFIX}
     volumes:
-      - "./wordpress:/var/www/html"
-      - "./plugins:/var/www/html/wp-content/plugins:cached"
+      - "nfsmount_WP:/var/www/html"
+      - "nfsmount_plugins:/var/www/html/wp-content/plugins:cached"
       - "./config/basic-wordpress-config.php:/tmp/wp-config.php:ro"
-      - "./xdebug:/var/xdebug:cached"
+      - "nfsmount_xdebug:/var/xdebug:cached"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
@@ -97,8 +97,8 @@ services:
       SITE_URL: ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
       VIRTUAL_HOST: ${WOOCOMMERCE_HOST:-woocommerce.wordpress.test}
     volumes:
-      - "./wordpress:/var/www/html"
-      - "./plugins:/var/www/html/wp-content/plugins:cached"
+      - "nfsmount_WP:/var/www/html"
+      - "nfsmount_plugins:/var/www/html/wp-content/plugins:cached"
       - "./config/woocommerce-wordpress-config.php:/tmp/wp-config.php:ro"
       - "./data/xdebug:/var/xdebug:cached"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
@@ -140,8 +140,8 @@ services:
       SITE_URL: ${MULTISITE_HOST:-multisite.wordpress.test}
       VIRTUAL_HOST: ${MULTISITE_HOST:-multisite.wordpress.test},test.${MULTISITE_HOST:-multisite.wordpress.test},translate.${MULTISITE_HOST:-multisite.wordpress.test}
     volumes:
-      - "./wordpress:/var/www/html"
-      - "./plugins:/var/www/html/wp-content/plugins:cached"
+      - "nfsmount_WP:/var/www/html"
+      - "nfsmount_plugins:/var/www/html/wp-content/plugins:cached"
       - "./config/multisite-wordpress-config.php:/tmp/wp-config.php:ro"
       - "./config/multisite.htaccess:/var/www/html/.htaccess:cached"
       - "./data/xdebug:/var/xdebug:cached"
@@ -184,8 +184,8 @@ services:
       SITE_URL: ${MULTISITE_HOST:-multisite.wordpress.test}
       VIRTUAL_HOST: ${MULTISITE_HOST:-multisite.wordpress.test},test.${MULTISITE_HOST:-multisite.wordpress.test},translate.${MULTISITE_HOST:-multisite.wordpress.test}
     volumes:
-      - "./wordpress:/var/www/html"
-      - "./plugins:/var/www/html/wp-content/plugins:cached"
+      - "nfsmount_WP:/var/www/html"
+      - "nfsmount_plugins:/var/www/html/wp-content/plugins:cached"
       - "./config/multisitedomain-wordpress-config.php:/tmp/wp-config.php:ro"
       - "./config/multisite.htaccess:/var/www/html/.htaccess:cached"
       - "./data/xdebug:/var/xdebug:cached"
@@ -228,15 +228,15 @@ services:
       SITE_URL: ${STANDALONE_HOST:-standalone.wordpress.test}
       VIRTUAL_HOST: ${STANDALONE_HOST:-standalone.wordpress.test}
     volumes:
-      - "./wordpress:/var/www/html"
+      - "nfsmount_WP:/var/www/html"
       - "./sa-plugins:/var/www/html/wp-content/plugins:cached"
       - "./config/standalone-wordpress-config.php:/tmp/wp-config.php:ro"
-      - "./xdebug:/var/xdebug:cached"
+      - "nfsmount_xdebug:/var/xdebug:cached"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     extra_hosts:
       - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
-# Nightly WordPress:
+  # Nightly WordPress:
   nightly-database:
     container_name: "wordpress-nightly-database"
     image: "mysql:5.7"
@@ -269,10 +269,10 @@ services:
       SITE_URL: ${NIGHTLY_HOST:-nightly.wordpress.test}
       VIRTUAL_HOST: ${NIGHTLY_HOST:-nightly.wordpress.test}
     volumes:
-      - "./wordpress:/var/www/html"
-      - "./plugins:/var/www/html/wp-content/plugins:cached"
+      - "nfsmount_WP:/var/www/html"
+      - "nfsmount_plugins:/var/www/html/wp-content/plugins:cached"
       - "./config/nightly-wordpress-config.php:/tmp/wp-config.php:ro"
-      - "./xdebug:/var/xdebug:cached"
+      - "nfsmount_xdebug:/var/xdebug:cached"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
@@ -283,6 +283,24 @@ volumes:
   basic-database-data:
   woocommerce-database-data:
   multisite-database-data:
-  multisitedomain-database-data: 
+  multisitedomain-database-data:
   standalone-database-data:
   nightly-database-data:
+  nfsmount_WP:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/wordpress"
+  nfsmount_plugins:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/wordpress"
+  nfsmount_xdebug:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}/wordpress"

--- a/start.sh
+++ b/start.sh
@@ -174,6 +174,6 @@ PROCESS=$!
 
 #run platform specific maintenance tasks every 5 seconds 
 while [ "$STOPPING" != 'true' ]; do
-	platform_tasks
+	#platform_tasks
 	sleep 5
 done

--- a/start.sh
+++ b/start.sh
@@ -149,6 +149,8 @@ if [[ "$PLATFORM" == WINDOWS ]]; then
 else
 	# supports mac and linux
 	source config/start_mac.sh
+    export DOCKER_NETWORK_HOST=$(ipconfig getifaddr en0)
+    check_lima_node
 fi
 
 create_dockerfile


### PR DESCRIPTION
Since Docker Desktop is moving to a Subscription-based model, we are moving to Rancher Desktop. This PR enables the usage of Rancher Desktop on macOS-based computers.

## How to test
- Follow the new instructions in [Rancher-mac.md](./Rancher-mac.md)
- Start the Environment by running:
  - `./clean.sh`, `./make.sh` & `./start.sh`
- Visit http://basic.wordpress.test to ensure the environment is working