### PR TITLE
Remove manual docker network host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,8 +61,6 @@ services:
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
-    extra_hosts:
-      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
   # WooCommerce WordPress:
   woocommerce-database:
@@ -104,8 +102,6 @@ services:
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
-    extra_hosts:
-      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
   # Multisite WordPress:
   multisite-database:
@@ -148,8 +144,6 @@ services:
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
-    extra_hosts:
-      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
   # Multisite WordPress using Subdomains:
   multisitedomain-database:
@@ -192,8 +186,6 @@ services:
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
-    extra_hosts:
-      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
   # Standalone WordPress:
   standalone-database:
@@ -233,8 +225,6 @@ services:
       - "./config/standalone-wordpress-config.php:/tmp/wp-config.php:ro"
       - "nfsmount_xdebug:/var/xdebug:cached"
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
-    extra_hosts:
-      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
   # Nightly WordPress:
   nightly-database:
@@ -276,8 +266,6 @@ services:
       - "./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:cached"
     labels:
       - com.yoast.plugin-development-docker.mainwpinstance
-    extra_hosts:
-      - "host.docker.internal:${DOCKER_NETWORK_HOST}"
 
 volumes:
   basic-database-data:


### PR DESCRIPTION
Rancher 1.1.1 has fixed the host.docker.internal issues, so we no longer have to set this host manually. 

This PR also introduces a check for Mac to make sure that the developer is on a Rancher version that we can set. This can help us force developers to update Rancher if we start using features in newer versions. With a tool as Rancher, that is evolving continuously, that seemed like the right thing to do. This check should also be made for Windows, though I don't know how to get the Rancher version on a Windows machine.