### PR TITLE
Updates to the mac starting scripts

### DIFF
--- a/config/start_mac.sh
+++ b/config/start_mac.sh
@@ -100,29 +100,6 @@ function start_docker_app() {
 }
 
 #######################################
-# Synchronizes Docker & Mac Clock to prevent issues
-# Globals:
-#   None
-# Arguments:
-#   None
-# Outputs:
-#   None
-#######################################
-function synchronize_clocks() {
-	CLOCK_SOURCE=$(docker exec -ti nginx-router-wordpress /bin/bash -c 'cat /sys/devices/system/clocksource/clocksource0/current_clocksource' | tr -d '[:space:]')
-	if [[ "$CLOCK_SOURCE" != 'tsc' && "$STOPPING" != 'true' ]]; then
-		echo "Restarting docker now to fix out-of-sync hardware clock!"
-		docker ps -q | xargs -L1 docker stop
-		
-		quit_docker_app
-		start_docker_app
-
-		echo "Docker is up and running again! Booting containers!"
-		boot_containers
-	fi
-}
-
-#######################################
 # Function that groups tasks depending on platform
 # Globals:
 #   None
@@ -132,9 +109,7 @@ function synchronize_clocks() {
 #   None
 #######################################
 function platform_tasks() {
-	if [[ "$PLATFORM" == APPLE && "$CLOCK_SYNC" == true ]]; then
-		synchronize_clocks
-	fi
+	:
 }
 
 #######################################

--- a/start.sh
+++ b/start.sh
@@ -204,7 +204,7 @@ if [[ "$PLATFORM" == WINDOWS ]]; then
 else
     # Default rancher location, it may be different depending on the user deciding to install the app somewhere else.
     default_rancher_loc='/Applications/Rancher Desktop.app/Contents/Resources/resources/linux/rancher-desktop.appdata.xml'
-    rancher_desktop_version=$(grep -P "release version=\".+?\"" "${default_rancher_loc}" | cut -d '"' -f 2)
+    rancher_desktop_version=$(grep -E "release version=\".+?\"" "${default_rancher_loc}" | cut -d '"' -f 2)
     rancher_should_be="1.1.1"
 
     # Compare the versions and exit if the used version is too old.


### PR DESCRIPTION
- Removes the clock synchronization function as it wasn't used anymore.
  - I left the platform-specific function in tact for possible later usage.
- Replaces the `-P` grep argument with `-E` so that mac grep BSD handles the regex pattern successfully.