### PR TITLE
Deprecate rancher for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mac users:
 > 
 > Do not clone to your documents folder as this will cause permission issues.
 
-- [Rancher Desktop](https://rancherdesktop.io/) see the [Rancher-mac.md](./Rancher-mac.md) guide on how to switch.
+- [OrbStack](https://yoast.atlassian.net/wiki/spaces/OPS/pages/3243376643/Container+managers) includes everything you need.
 
 Windows WSL2:
 Running this setup from WSL is the preferd way. 

--- a/Rancher-mac.md
+++ b/Rancher-mac.md
@@ -1,5 +1,5 @@
 # Switching to Rancher Desktop on MacOS
-
+> This is deprecated. Use [this](https://yoast.atlassian.net/wiki/spaces/OPS/pages/3243376643/Container+managers) page to install the currently supported container manager. 
 ## Removing old entries
 
 - Uninstall Docker Desktop


### PR DESCRIPTION
# Context
Changed documentation for Mac users from Rancher to Orbstack.

# Test instructions
Read the document changes to see if its correct.