### PR TITLE
Fix unquoted args in WP CLI command

### DIFF
--- a/wp.sh
+++ b/wp.sh
@@ -21,4 +21,4 @@ elif [[ "$((count_containers))" > 1 ]]; then
 fi
 
 # Execute the WP-CLI command
-docker exec -ti --user www-data $CONTAINER wp $@
+docker exec -ti --user www-data "$CONTAINER" wp "$@"


### PR DESCRIPTION
**Without the fix**:
* `./wp.sh post create --post_status=publish --post_title="Hiking Boots Review"` fails with `Error: Too many positional arguments`

**With the fix**:
* `./wp.sh post create --post_status=publish --post_title="Hiking Boots Review"` works